### PR TITLE
Add wait until active when creating a connection

### DIFF
--- a/pureport/exception/api.py
+++ b/pureport/exception/api.py
@@ -8,14 +8,18 @@ class MissingAccessTokenException(IOError):
     pass
 
 
-class ConnectionFailedToBecomeActiveException(IOError):
+class OperationTimeoutException(IOError):
+    pass
+
+
+class ConnectionOperationTimeoutException(OperationTimeoutException):
     def __init__(self, *args, **kwargs):
         """
-        An exception representing the connection failed to become active
+        An connection operation took too long to perform
         :param Connection connection: the connection
         """
         self.connection = kwargs.pop('connection', None)
-        super(ConnectionFailedToBecomeActiveException, self).__init__(*args, **kwargs)
+        super(OperationTimeoutException, self).__init__(*args, **kwargs)
 
 
 class ClientHttpException(IOError):

--- a/pureport/exception/api.py
+++ b/pureport/exception/api.py
@@ -8,6 +8,16 @@ class MissingAccessTokenException(IOError):
     pass
 
 
+class ConnectionFailedToBecomeActiveException(IOError):
+    def __init__(self, *args, **kwargs):
+        """
+        An exception representing the connection failed to become active
+        :param Connection connection: the connection
+        """
+        self.connection = kwargs.pop('connection', None)
+        super(ConnectionFailedToBecomeActiveException, self).__init__(*args, **kwargs)
+
+
 class ClientHttpException(IOError):
     def __init__(self, *args, **kwargs):
         """

--- a/pureport/exception/api.py
+++ b/pureport/exception/api.py
@@ -8,18 +8,24 @@ class MissingAccessTokenException(IOError):
     pass
 
 
-class OperationTimeoutException(IOError):
-    pass
-
-
-class ConnectionOperationTimeoutException(OperationTimeoutException):
+class ConnectionOperationTimeoutException(IOError):
     def __init__(self, *args, **kwargs):
         """
         An connection operation took too long to perform
         :param Connection connection: the connection
         """
         self.connection = kwargs.pop('connection', None)
-        super(OperationTimeoutException, self).__init__(*args, **kwargs)
+        super(ConnectionOperationTimeoutException, self).__init__(*args, **kwargs)
+
+
+class ConnectionOperationFailedException(IOError):
+    def __init__(self, *args, **kwargs):
+        """
+        An connection operation failed to perform
+        :param Connection connection: the connection
+        """
+        self.connection = kwargs.pop('connection', None)
+        super(ConnectionOperationFailedException, self).__init__(*args, **kwargs)
 
 
 class ClientHttpException(IOError):

--- a/pureport/util/decorators.py
+++ b/pureport/util/decorators.py
@@ -1,0 +1,31 @@
+import time
+from functools import wraps
+
+
+def retry(exception, tries=10, delay=1, backoff=2, max_delay=30):
+    """
+    Retry calling the decorated function using an exponential backoff.
+    http://www.saltycrane.com/blog/2009/11/trying-out-retry-decorator-python/
+    original from: http://wiki.python.org/moin/PythonDecoratorLibrary#Retry
+    The default here allows for 181 seconds of retry.
+    1 + 2 + 4 + 8 + 16 + 30 + 30 + 30 + 30 + 30 = 181
+    :param Exception exception: the exception to check. may be a tuple of exceptions to check
+    :param int tries: number of times to try (not retry) before giving up
+    :param int delay: initial delay between retries in seconds
+    :param int backoff: backoff multiplier e.g. value of 2 will double the delay each retry
+    :param int max_delay: the maximum time between each retry
+    """
+    def deco_retry(f):
+        @wraps(f)
+        def f_retry(*args, **kwargs):
+            m_tries, m_delay = tries, delay
+            while m_tries > 1:
+                try:
+                    return f(*args, **kwargs)
+                except exception:
+                    time.sleep(min(m_delay, max_delay))
+                    m_tries -= 1
+                    m_delay *= backoff
+            return f(*args, **kwargs)
+        return f_retry  # true decorator
+    return deco_retry

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,8 @@ setup(
         'pureport.util'
     ],
     install_requires=[
-        'requests'
+        'requests',
+        'enum34'
     ],
     classifiers=[
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
When creating a connection, this will perform an exponential backoff get to retrieve the connection before returning back to the user.  With the defaults here, it will retry for up to 181 seconds.  If it exceeds that amount it will eventually `raise ConnectionFailedToBecomeActiveException`, which contains the last state of the connection object.

For example:
```python
new_connection = None
try:
    new_connection = client.networks.connections(new_network).create(new_connection_data)
except ClientHttpException as e:
    print(e.response.text)
except ConnectionFailedToBecomeActiveException as e:
    new_connection = e.connection
```

Users may optionally pass `false` or `wait_until_active=False` to ignore this functionality.