### PR TITLE
Refactoring the API client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,14 @@
 # Pureport Python Client
-A thin Python 2/3 client for the Pureport ReST API, backed by [requests](http://docs.python-requests.org/en/master/).
+A thin Python 3 client for the Pureport ReST API, backed by [requests](http://docs.python-requests.org/en/master/).
 
 ## Install
 ```bash
 pip install pureport-client
+```
+
+For Python2, you can use any version prior to 1.0.0.
+```bash
+pip install pureport-client<1
 ```
 
 ## Usage
@@ -20,10 +25,10 @@ accounts = client.accounts.list()
 first_account = accounts[0]
 
 ### List all Networks for the first Account
-networks = client.accounts.networks(first_account).list()
+networks = client.accounts.networks(first_account['id']).list()
 
 ### Create a Network for the Account
-new_network = client.accounts.networks(first_account).create({
+new_network = client.accounts.networks(first_account['id']).create({
     'name': 'My First Network'
 })
 
@@ -48,25 +53,22 @@ new_connection_data = {
 
 new_connection = None
 try:
-    new_connection = client.networks.connections(new_network).create(new_connection_data)
+    new_connection = client.networks.connections(new_network['id']).create(new_connection_data)
 except ClientHttpException as e:
     print(e.response.text)
     
 ### Retrieve the new AWS Connection by the returned object
-client.connections.get(new_connection)
-
-### Retrieve the new AWS Connection by it's 'id'
-client.connections.get_by_id(new_connection['id'])
+client.connections.get(new_connection['id'])
 
 ### Delete the new AWS Connection
-client.connections.delete(new_connection)
+client.connections.delete(new_connection['id'])
 
 ### Expect a 404 error for the deleted connection
 try:
-    client.connections.get(new_connection)
+    client.connections.get(new_connection['id'])
 except NotFoundException as e:
     print(e.response.text)
     
 ### Delete the Network
-client.networks.delete(new_network)
+client.networks.delete(new_network['id'])
 ```

--- a/pureport/api/client.py
+++ b/pureport/api/client.py
@@ -235,7 +235,7 @@ class Client(object):
                     'limit': limit
                 }).json()
 
-        def get_by_id(self, account_id):
+        def get(self, account_id):
             """
             Get an account by its id.
             :param str account_id: the account id
@@ -243,15 +243,6 @@ class Client(object):
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/accounts/%s' % account_id).json()
-
-        def get(self, account):
-            """
-            Get an account using the provided account object.
-            :param Account account: the account object
-            :rtype: Account
-            :raises: .exception.HttpClientException
-            """
-            return self.__session.get(account['href']).json()
 
         def create(self, account):
             """
@@ -269,145 +260,145 @@ class Client(object):
             :rtype: Account
             :raises: .exception.HttpClientException
             """
-            return self.__session.put(account['href'], json=account).json()
+            return self.__session.put('/accounts/%s' % account['id'], json=account).json()
 
-        def delete(self, account):
+        def delete(self, account_id):
             """
             Delete an account.
-            :param Account account: the account object
+            :param str account_id: the account id
             :raises: .exception.HttpClientException
             """
-            self.__session.delete(account['href'])
+            self.__session.delete('/accounts/%s' % account_id)
 
-        def api_keys(self, account):
+        def api_keys(self, account_id):
             """
             Get the account api keys client using the provided account.
-            :param Account account: the account object
+            :param str account_id: the account id
             :rtype: Client.AccountAPIKeysClient
             """
-            return Client.AccountAPIKeysClient(self.__session, account)
+            return Client.AccountAPIKeysClient(self.__session, account_id)
 
-        def audit_log(self, account):
+        def audit_log(self, account_id):
             """
             Get the account audit log client using the provided account.
-            :param Account account: the account object
+            :param str account_id: the account id
             :rtype: Client.AccountAuditLogClient
             """
-            return Client.AccountAuditLogClient(self.__session, account)
+            return Client.AccountAuditLogClient(self.__session, account_id)
 
-        def billing(self, account):
+        def billing(self, account_id):
             """
             Get the account billing client using the provided account.
-            :param Account account: the account object
+            :param str account_id: the account id
             :rtype: Client.AccountBillingClient
             """
-            return Client.AccountBillingClient(self.__session, account)
+            return Client.AccountBillingClient(self.__session, account_id)
 
-        def connections(self, account):
+        def connections(self, account_id):
             """
             Get the account connections client using the provided account.
-            :param Account account: the account object
+            :param str account_id: the account id
             :rtype: Client.AccountConnectionsClient
             """
-            return Client.AccountConnectionsClient(self.__session, account)
+            return Client.AccountConnectionsClient(self.__session, account_id)
 
-        def consent(self, account):
+        def consent(self, account_id):
             """
             Get the account consent client using the provided account.
-            :param Account account: the account object
+            :param str account_id: the account id
             :rtype: Client.AccountConsentClient
             """
-            return Client.AccountConsentClient(self.__session, account)
+            return Client.AccountConsentClient(self.__session, account_id)
 
-        def invites(self, account):
+        def invites(self, account_id):
             """
             Get the account invites client using the provided account.
-            :param Account account: the account object
+            :param str account_id: the account id
             :rtype: Client.AccountInvitesClient
             """
-            return Client.AccountInvitesClient(self.__session, account)
+            return Client.AccountInvitesClient(self.__session, account_id)
 
-        def invoices(self, account):
+        def invoices(self, account_id):
             """
             Get the account invoices client using the provided account.
-            :param Account account: the account object
+            :param str account_id: the account id
             :rtype: Client.AccountInvoicesClient
             """
-            return Client.AccountInvoicesClient(self.__session, account)
+            return Client.AccountInvoicesClient(self.__session, account_id)
 
-        def members(self, account):
+        def members(self, account_id):
             """
             Get the account members client using the provided account.
-            :param Account account: the account object
+            :param str account_id: the account id
             :rtype: Client.AccountMembersClient
             """
-            return Client.AccountMembersClient(self.__session, account)
+            return Client.AccountMembersClient(self.__session, account_id)
 
-        def metrics(self, account):
+        def metrics(self, account_id):
             """
             Get the account metrics client using the provided account.
-            :param Account account: the account object
+            :param str account_id: the account id
             :rtype: Client.AccountMetricsClient
             """
-            return Client.AccountMetricsClient(self.__session, account)
+            return Client.AccountMetricsClient(self.__session, account_id)
 
-        def networks(self, account):
+        def networks(self, account_id):
             """
             Get the account networks client using the provided account.
-            :param Account account: the account object
+            :param str account_id: the account id
             :rtype: Client.AccountNetworksClient
             """
-            return Client.AccountNetworksClient(self.__session, account)
+            return Client.AccountNetworksClient(self.__session, account_id)
 
-        def permissions(self, account):
+        def permissions(self, account_id):
             """
             Get the account permissions client using the provided account.
-            :param Account account: the account object
+            :param str account_id: the account id
             :rtype: Client.AccountPermissionsClient
             """
-            return Client.AccountPermissionsClient(self.__session, account)
+            return Client.AccountPermissionsClient(self.__session, account_id)
 
-        def ports(self, account):
+        def ports(self, account_id):
             """
             Get the account ports client using the provided account.
-            :param Account account: the account object
+            :param str account_id: the account id
             :rtype: Client.AccountPortsClient
             """
-            return Client.AccountPortsClient(self.__session, account)
+            return Client.AccountPortsClient(self.__session, account_id)
 
-        def roles(self, account):
+        def roles(self, account_id):
             """
             Get the account roles client using the provided account.
-            :param Account account: the account object
+            :param str account_id: the account id
             :rtype: Client.AccountRolesClient
             """
-            return Client.AccountRolesClient(self.__session, account)
+            return Client.AccountRolesClient(self.__session, account_id)
 
-        def supported_connections(self, account):
+        def supported_connections(self, account_id):
             """
             Get the account supported connections client using the provided account.
-            :param Account account: the account object
+            :param str account_id: the account id
             :rtype: Client.AccountSupportedConnectionsClient
             """
-            return Client.AccountSupportedConnectionsClient(self.__session, account)
+            return Client.AccountSupportedConnectionsClient(self.__session, account_id)
 
-        def supported_ports(self, account):
+        def supported_ports(self, account_id):
             """
             Get the account supported ports client using the provided account.
-            :param Account account: the account object
+            :param str account_id: the account id
             :rtype: Client.AccountSupportedConnectionsClient
             """
-            return Client.AccountSupportedPortsClient(self.__session, account)
+            return Client.AccountSupportedPortsClient(self.__session, account_id)
 
     class AccountAPIKeysClient(object):
-        def __init__(self, session, account):
+        def __init__(self, session, account_id):
             """
             The Account API Keys client
             :param RelativeSession session:
-            :param Account account:
+            :param str account_id:
             """
             self.__session = session
-            self.__account = account
+            self.__account_id = account_id
 
         def list(self):
             """
@@ -415,25 +406,16 @@ class Client(object):
             :rtype: list[APIKey]
             :raises: .exception.HttpClientException
             """
-            return self.__session.get('%s/apikeys' % self.__account['href']).json()
+            return self.__session.get('/accounts/%s/apikeys' % self.__account_id).json()
 
-        def get_by_id(self, api_key_key):
+        def get(self, api_key_key):
             """
             Get an account's API Key with the provided API Key key.
             :param str api_key_key: the key of an API Key
             :rtype: APIKey
             :raises: .exception.HttpClientException
             """
-            return self.__session.get('%s/apikeys/%s' % (self.__account['href'], api_key_key)).json()
-
-        def get(self, api_key):
-            """
-            Get an account's API Key with the provided API Key object.
-            :param APIKey api_key: the APIKey object
-            :rtype: APIKey
-            :raises: .exception.HttpClientException
-            """
-            return self.__session.get('%s/apikeys/%s' % (self.__account['href'], api_key['key'])).json()
+            return self.__session.get('/accounts/%s/apikeys/%s' % (self.__account_id, api_key_key)).json()
 
         def create(self, api_key):
             """
@@ -442,7 +424,7 @@ class Client(object):
             :rtype: APIKey
             :raises: .exception.HttpClientException
             """
-            return self.__session.post('%s/apikeys' % self.__account['href'], json=api_key).json()
+            return self.__session.post('/accounts/%s/apikeys' % self.__account_id, json=api_key).json()
 
         def update(self, api_key):
             """
@@ -451,25 +433,28 @@ class Client(object):
             :rtype: APIKey
             :raises: .exception.HttpClientException
             """
-            return self.__session.put('%s/apikeys/%s' % (self.__account['href'], api_key['key']), json=api_key).json()
+            return self.__session.put(
+                '/accounts/%s/apikeys/%s' % (self.__account_id, api_key['key']),
+                json=api_key
+            ).json()
 
-        def delete(self, api_key):
+        def delete(self, api_key_key):
             """
             Delete an API Key from the provided account.
-            :param APIKey api_key: the APIKey object
+            :param str api_key_key: the APIKey key name
             :raises: .exception.HttpClientException
             """
-            self.__session.delete('%s/apikeys/%s' % (self.__account['href'], api_key['key']))
+            self.__session.delete('/accounts/%s/apikeys/%s' % (self.__account_id, api_key_key))
 
     class AccountAuditLogClient(object):
-        def __init__(self, session, account):
+        def __init__(self, session, account_id):
             """
             The Account Audit Log client
             :param RelativeSession session:
-            :param Account account:
+            :param str account_id:
             """
             self.__session = session
-            self.__account = account
+            self.__account_id = account_id
 
         def query(self, page_number=None, page_size=None, sort=None, sort_direction=None,
                   start_time=None, end_time=None, include_child_accounts=None, event_types=None,
@@ -495,7 +480,7 @@ class Client(object):
             :raises: .exception.HttpClientException
             """
             return self.__session.get(
-                '%s/auditLog' % self.__account['href'],
+                '/accounts/%s/auditLog' % self.__account_id,
                 params={
                     'pageNumber': page_number,
                     'pageSize': page_size,
@@ -515,14 +500,14 @@ class Client(object):
             ).json()
 
     class AccountBillingClient(object):
-        def __init__(self, session, account):
+        def __init__(self, session, account_id):
             """
             The Account Billing client
             :param RelativeSession session:
-            :param Account account:
+            :param str account_id:
             """
             self.__session = session
-            self.__account = account
+            self.__account_id = account_id
 
         def get(self):
             """
@@ -532,7 +517,7 @@ class Client(object):
             :rtype: AccountBilling
             :raises: .exception.HttpClientException
             """
-            return self.__session.get('%s/billing' % self.__account['href']).json()
+            return self.__session.get('/accounts/%s/billing' % self.__account_id).json()
 
         def get_configured(self):
             """
@@ -541,7 +526,7 @@ class Client(object):
             :rtype: AccountBilling
             :raises: .exception.HttpClientException
             """
-            return self.__session.get('%s/billing/configured' % self.__account['href']).json()
+            return self.__session.get('/accounts/%s/billing/configured' % self.__account_id).json()
 
         def create(self, account_billing):
             """
@@ -550,7 +535,7 @@ class Client(object):
             :rtype: AccountBilling
             :raises: .exception.HttpClientException
             """
-            return self.__session.post('%s/billing' % self.__account['href'], json=account_billing).json()
+            return self.__session.post('/accounts/%s/billing' % self.__account_id, json=account_billing).json()
 
         def update(self, account_billing):
             """
@@ -559,24 +544,24 @@ class Client(object):
             :rtype: AccountBilling
             :raises: .exception.HttpClientException
             """
-            return self.__session.put('%s/billing' % self.__account['href'], json=account_billing).json()
+            return self.__session.put('/accounts/%s/billing' % self.__account_id, json=account_billing).json()
 
         def delete(self):
             """
             Delete the current AccountBilling object from the account if it exists.
             :raises: .exception.HttpClientException
             """
-            self.__session.delete('%s/billing' % self.__account['href'])
+            self.__session.delete('/accounts/%s/billing' % self.__account_id)
 
     class AccountConnectionsClient(object):
-        def __init__(self, session, account):
+        def __init__(self, session, account_id):
             """
             The Account Connections client
             :param RelativeSession session:
-            :param Account account:
+            :param str account_id:
             """
             self.__session = session
-            self.__account = account
+            self.__account_id = account_id
 
         def list(self):
             """
@@ -584,17 +569,17 @@ class Client(object):
             :rtype: list[Connection]
             :raises: .exception.HttpClientException
             """
-            return self.__session.get('%s/connections' % self.__account['href']).json()
+            return self.__session.get('/accounts/%s/connections' % self.__account_id).json()
 
     class AccountConsentClient(object):
-        def __init__(self, session, account):
+        def __init__(self, session, account_id):
             """
             The Account Consent Client client
             :param RelativeSession session:
-            :param Account account:
+            :param str account_id:
             """
             self.__session = session
-            self.__account = account
+            self.__account_id = account_id
 
         def get(self):
             """
@@ -602,7 +587,7 @@ class Client(object):
             :rtype: AccountConsent
             :raises: .exception.HttpClientException
             """
-            return self.__session.get('%s/consent' % self.__account['href']).json()
+            return self.__session.get('/accounts/%s/consent' % self.__account_id).json()
 
         def accept(self):
             """
@@ -610,17 +595,17 @@ class Client(object):
             :rtype: AccountConsent
             :raises: .exception.HttpClientException
             """
-            return self.__session.post('%s/consent' % self.__account['href']).json()
+            return self.__session.post('/accounts/%s/consent' % self.__account_id).json()
 
     class AccountInvitesClient(object):
-        def __init__(self, session, account):
+        def __init__(self, session, account_id):
             """
             The Account Invites client
             :param RelativeSession session:
-            :param Account account:
+            :param str account_id:
             """
             self.__session = session
-            self.__account = account
+            self.__account_id = account_id
 
         def list(self):
             """
@@ -628,25 +613,16 @@ class Client(object):
             :rtype: list[AccountInvite]
             :raises: .exception.HttpClientException
             """
-            return self.__session.get('%s/invites' % self.__account['href']).json()
+            return self.__session.get('/accounts/%s/invites' % self.__account_id).json()
 
-        def get_by_id(self, invite_id):
+        def get(self, invite_id):
             """
             Get an account's invite with the provided account invite id.
             :param str invite_id: the account invite id
             :rtype: AccountInvite
             :raises: .exception.HttpClientException
             """
-            return self.__session.get('%s/invites/%s' % (self.__account['href'], invite_id)).json()
-
-        def get(self, invite):
-            """
-            Get an account's invite using the provided account invite.
-            :param AccountInvite invite: the account invite object
-            :rtype: AccountInvite
-            :raises: .exception.HttpClientException
-            """
-            return self.__session.get('%s/invites/%s' % (self.__account['href'], invite['id'])).json()
+            return self.__session.get('/accounts/%s/invites/%s' % (self.__account_id, invite_id)).json()
 
         def create(self, invite):
             """
@@ -655,7 +631,7 @@ class Client(object):
             :rtype: AccountInvite
             :raises: .exception.HttpClientException
             """
-            return self.__session.post('%s/invites' % self.__account['href'], json=invite).json()
+            return self.__session.post('/accounts/%s/invites' % self.__account_id, json=invite).json()
 
         def update(self, invite):
             """
@@ -664,25 +640,28 @@ class Client(object):
             :rtype: AccountInvite
             :raises: .exception.HttpClientException
             """
-            return self.__session.put('%s/invites/%s' % (self.__account['href'], invite['id']), json=invite).json()
+            return self.__session.put(
+                '/accounts/%s/invites/%s' % (self.__account_id, invite['id']),
+                json=invite
+            ).json()
 
-        def delete(self, invite):
+        def delete(self, invite_id):
             """
             Delete an account invite using the provided account.
-            :param AccountInvite invite: the account invite object
+            :param str invite_id: the account invite id
             :raises: .exception.HttpClientException
             """
-            self.__session.delete('%s/invites/%s' % (self.__account['href'], invite['id']))
+            self.__session.delete('/accounts/%s/invites/%s' % (self.__account_id, invite_id))
 
     class AccountInvoicesClient(object):
-        def __init__(self, session, account):
+        def __init__(self, session, account_id):
             """
             The Account Invoices client
             :param RelativeSession session:
-            :param Account account:
+            :param str account_id:
             """
             self.__session = session
-            self.__account = account
+            self.__account_id = account_id
 
         def list(self, invoice_filter):
             """
@@ -692,7 +671,7 @@ class Client(object):
             :rtype: list[NetworkInvoice]
             :raises: .exception.HttpClientException
             """
-            return self.__session.post('%s/invoices' % self.__account['href'], json=invoice_filter).json()
+            return self.__session.post('/accounts/%s/invoices' % self.__account_id, json=invoice_filter).json()
 
         def list_upcoming(self):
             """
@@ -700,17 +679,17 @@ class Client(object):
             :rtype: list[NetworkInvoice]
             :raises: .exception.HttpClientException
             """
-            return self.__session.get('%s/invoices/upcoming' % self.__account['href']).json()
+            return self.__session.get('/accounts/%s/invoices/upcoming' % self.__account_id).json()
 
     class AccountMembersClient(object):
-        def __init__(self, session, account):
+        def __init__(self, session, account_id):
             """
             The Account Members client
             :param RelativeSession session:
-            :param Account account:
+            :param str account_id:
             """
             self.__session = session
-            self.__account = account
+            self.__account_id = account_id
 
         def list(self):
             """
@@ -718,25 +697,16 @@ class Client(object):
             :rtype: list[AccountMember]
             :raises: .exception.HttpClientException
             """
-            return self.__session.get('%s/members' % self.__account['href']).json()
+            return self.__session.get('/accounts/%s/members' % self.__account_id).json()
 
-        def get_by_id(self, user_id):
+        def get(self, user_id):
             """
             Get a member by their user id for the provided account.
             :param str user_id: a user id
             :rtype: AccountMember
             :raises: .exception.HttpClientException
             """
-            return self.__session.get('%s/members/%s' % (self.__account['href'], user_id)).json()
-
-        def get(self, member):
-            """
-            Get a member using a member object for the provided account.
-            :param AccountMember member: the account member object
-            :rtype: AccountMember
-            :raises: .exception.HttpClientException
-            """
-            return self.__session.get('%s/members/%s' % (self.__account['href'], member['user']['id'])).json()
+            return self.__session.get('/accounts/%s/members/%s' % (self.__account_id, user_id)).json()
 
         def create(self, member):
             """
@@ -746,7 +716,7 @@ class Client(object):
             :rtype: AccountMember
             :raises: .exception.HttpClientException
             """
-            return self.__session.post('%s/members' % self.__account['href'], json=member).json()
+            return self.__session.post('%s/members' % self.__account_id, json=member).json()
 
         def update(self, member):
             """
@@ -756,27 +726,27 @@ class Client(object):
             :raises: .exception.HttpClientException
             """
             return self.__session.put(
-                '%s/members/%s' % (self.__account['href'], member['user']['id']),
+                '/accounts/%s/members/%s' % (self.__account_id, member['user']['id']),
                 json=member
             ).json()
 
-        def delete(self, member):
+        def delete(self, user_id):
             """
             Delete a member from the provided account.
-            :param AccountMember member:  the account member object
+            :param str user_id: a user id
             :raises: .exception.HttpClientException
             """
-            self.__session.delete('%s/members/%s' % (self.__account['href'], member['user']['id']))
+            self.__session.delete('/accounts/%s/members/%s' % (self.__account_id, user_id))
 
     class AccountMetricsClient(object):
-        def __init__(self, session, account):
+        def __init__(self, session, account_id):
             """
             The Account Networks client
             :param RelativeSession session:
-            :param Account account:
+            :param str account_id:
             """
             self.__session = session
-            self.__account = account
+            self.__account_id = account_id
 
         def usage_by_connection(self, options):
             """
@@ -785,7 +755,10 @@ class Client(object):
             :rtype: list[NetworkConnectionEgressIngress]
             :raises: .exception.HttpClientException
             """
-            return self.__session.post('%s/metrics/usageByConnection' % self.__account['href'], json=options).json()
+            return self.__session.post(
+                '/accounts/%s/metrics/usageByConnection' % self.__account_id,
+                json=options
+            ).json()
 
         def usage_by_connection_and_time(self, options):
             """
@@ -795,7 +768,7 @@ class Client(object):
             :raises: .exception.HttpClientException
             """
             return self.__session.post(
-                '%s/metrics/usageByConnectionAndTime' % self.__account['href'],
+                '/accounts/%s/metrics/usageByConnectionAndTime' % self.__account_id,
                 json=options
             ).json()
 
@@ -806,17 +779,20 @@ class Client(object):
             :rtype: list[NetworkTimeUsage]
             :raises: .exception.HttpClientException
             """
-            return self.__session.post('%s/metrics/usageByNetworkAndTime' % self.__account['href'], json=options).json()
+            return self.__session.post(
+                '/accounts/%s/metrics/usageByNetworkAndTime' % self.__account_id,
+                json=options
+            ).json()
 
     class AccountNetworksClient(object):
-        def __init__(self, session, account):
+        def __init__(self, session, account_id):
             """
             The Account Networks client
             :param RelativeSession session:
-            :param Account account:
+            :param str account_id:
             """
             self.__session = session
-            self.__account = account
+            self.__account_id = account_id
 
         def list(self):
             """
@@ -824,7 +800,7 @@ class Client(object):
             :rtype: list[Network]
             :raises: .exception.HttpClientException
             """
-            return self.__session.get('%s/networks' % self.__account['href']).json()
+            return self.__session.get('/accounts/%s/networks' % self.__account_id).json()
 
         def create(self, network):
             """
@@ -833,17 +809,17 @@ class Client(object):
             :rtype: Network
             :raises: .exception.HttpClientException
             """
-            return self.__session.post('%s/networks' % self.__account['href'], json=network).json()
+            return self.__session.post('/accounts/%s/networks' % self.__account_id, json=network).json()
 
     class AccountPermissionsClient(object):
-        def __init__(self, session, account):
+        def __init__(self, session, account_id):
             """
             The Account Permissions client
             :param RelativeSession session:
-            :param Account account:
+            :param str account_id:
             """
             self.__session = session
-            self.__account = account
+            self.__account_id = account_id
 
         def get(self):
             """
@@ -852,17 +828,17 @@ class Client(object):
             :rtype: AccountPermissions
             :raises: .exception.HttpClientException
             """
-            return self.__session.get('%s/permissions' % self.__account['href']).json()
+            return self.__session.get('/accounts/%s/permissions' % self.__account_id).json()
 
     class AccountPortsClient(object):
-        def __init__(self, session, account):
+        def __init__(self, session, account_id):
             """
             The Account Ports client
             :param RelativeSession session:
-            :param Account account:
+            :param str account_id:
             """
             self.__session = session
-            self.__account = account
+            self.__account_id = account_id
 
         def list(self):
             """
@@ -870,7 +846,7 @@ class Client(object):
             :rtype: list[Port]
             :raises: .exception.HttpClientException
             """
-            return self.__session.get('%s/ports' % self.__account['href']).json()
+            return self.__session.get('/accounts/%s/ports' % self.__account_id).json()
 
         def create(self, port):
             """
@@ -879,17 +855,17 @@ class Client(object):
             :rtype: Port
             :raises: .exception.HttpClientException
             """
-            return self.__session.post('%s/ports' % self.__account['href'], json=port).json()
+            return self.__session.post('/accounts/%s/ports' % self.__account_id, json=port).json()
 
     class AccountRolesClient(object):
-        def __init__(self, session, account):
+        def __init__(self, session, account_id):
             """
             The Account Roles client
             :param RelativeSession session:
-            :param Account account:
+            :param str account_id:
             """
             self.__session = session
-            self.__account = account
+            self.__account_id = account_id
 
         def list(self):
             """
@@ -897,25 +873,16 @@ class Client(object):
             :rtype: list[AccountRole]
             :raises: .exception.HttpClientException
             """
-            return self.__session.get('%s/roles' % self.__account['href']).json()
+            return self.__session.get('/accounts/%s/roles' % self.__account_id).json()
 
-        def get_by_id(self, role_id):
+        def get(self, role_id):
             """
             Get a role by its id for the provided account.
             :param str role_id: the role id
             :rtype: AccountRole
             :raises: .exception.HttpClientException
             """
-            return self.__session.get('%s/roles/%s' % (self.__account['href'], role_id)).json()
-
-        def get(self, role):
-            """
-            Get a role using a role object for the provided account.
-            :param AccountRole role: the account role object
-            :rtype: AccountRole
-            :raises: .exception.HttpClientException
-            """
-            return self.__session.get('%s/roles/%s' % (self.__account['href'], role['id'])).json()
+            return self.__session.get('/accounts/%s/roles/%s' % (self.__account_id, role_id)).json()
 
         def create(self, role):
             """
@@ -924,7 +891,7 @@ class Client(object):
             :rtype: AccountRole
             :raises: .exception.HttpClientException
             """
-            return self.__session.post('%s/roles' % self.__account['href'], json=role).json()
+            return self.__session.post('/accounts/%s/roles' % self.__account_id, json=role).json()
 
         def update(self, role):
             """
@@ -933,25 +900,25 @@ class Client(object):
             :rtype: AccountRole
             :raises: .exception.HttpClientException
             """
-            return self.__session.put('%s/roles/%s' % (self.__account['href'], role['id']), json=role).json()
+            return self.__session.put('%s/roles/%s' % (self.__account_id, role['id']), json=role).json()
 
-        def delete(self, role):
+        def delete(self, role_id):
             """
             Update a role for the provided account.
-            :param AccountRole role: the account role object
+            :param str role_id: the role id
             :raises: .exception.HttpClientException
             """
-            self.__session.delete('%s/roles/%s' % (self.__account['href'], role['id']))
+            self.__session.delete('/accounts/%s/roles/%s' % (self.__account_id, role_id))
 
     class AccountSupportedConnectionsClient(object):
-        def __init__(self, session, account):
+        def __init__(self, session, account_id):
             """
             The Account Supported Connections client
             :param RelativeSession session:
-            :param Account account:
+            :param str account_id:
             """
             self.__session = session
-            self.__account = account
+            self.__account_id = account_id
 
         def list(self):
             """
@@ -959,17 +926,17 @@ class Client(object):
             :rtype: list[SupportedConnection]
             :raises: .exception.HttpClientException
             """
-            return self.__session.get('%s/supportedConnections' % self.__account['href']).json()
+            return self.__session.get('/accounts/%s/supportedConnections' % self.__account_id).json()
 
     class AccountSupportedPortsClient(object):
-        def __init__(self, session, account):
+        def __init__(self, session, account_id):
             """
             The Account Supported Ports client
             :param RelativeSession session:
-            :param Account account:
+            :param str account_id:
             """
             self.__session = session
-            self.__account = account
+            self.__account_id = account_id
 
         def list(self, facility):
             """
@@ -979,7 +946,7 @@ class Client(object):
             :raises: .exception.HttpClientException
             """
             return self.__session.get(
-                '%s/supportedPorts' % self.__account['href'],
+                '/accounts/%s/supportedPorts' % self.__account_id,
                 params={'facility': facility['id']}
             ).json()
 
@@ -999,7 +966,7 @@ class Client(object):
             """
             return self.__session.get('/cloudRegions').json()
 
-        def get_by_id(self, cloud_region_id):
+        def get(self, cloud_region_id):
             """
             Get the cloud region with the provided cloud region id.
             :param str cloud_region_id: the cloud region id
@@ -1007,15 +974,6 @@ class Client(object):
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/cloudRegions/%s' % cloud_region_id).json()
-
-        def get(self, cloud_region):
-            """
-            Get the cloud region using the provided cloud region object.
-            :param CloudRegion cloud_region: the cloud region object
-            :rtype: CloudRegion
-            :raises: .exception.HttpClientException
-            """
-            return self.__session.get(cloud_region['href']).json()
 
     class CloudServicesClient(object):
         def __init__(self, session):
@@ -1033,7 +991,7 @@ class Client(object):
             """
             return self.__session.get('/cloudServices').json()
 
-        def get_by_id(self, cloud_service_id):
+        def get(self, cloud_service_id):
             """
             Get the cloud service with the provided cloud service id.
             :param str cloud_service_id: the cloud service id
@@ -1041,15 +999,6 @@ class Client(object):
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/cloudServices/%s' % cloud_service_id).json()
-
-        def get(self, cloud_service):
-            """
-            Get the cloud service using the provided cloud service object.
-            :param CloudService cloud_service: the cloud service object
-            :rtype: CloudService
-            :raises: .exception.HttpClientException
-            """
-            return self.__session.get(cloud_service['href']).json()
 
     class ConnectionsClient(object):
         def __init__(self, session):
@@ -1061,19 +1010,18 @@ class Client(object):
 
         @staticmethod
         @retry(ConnectionOperationTimeoutException)
-        def get_connection_until_state(session, connection, expected_state, failed_states=[]):
+        def get_connection_until_state(session, connection_id, expected_state, failed_states):
             """
             Retrieve a connection until it enters a certain state using an exponential backoff
             :param RelativeSession session: a :class:`Client`'s relative session
-            :param Connection connection: the connection
+            :param str connection_id: the connection id
             :param ConnectionState expected_state: the expected state
             :param list[ConnectionState] failed_states: a list of failed states that instead
-                raise ConnectionOperationFailedException
             :rtype: Connection
             :raises: .exception.ConnectionOperationTimeoutException
             :raises: .exception.ConnectionOperationFailedException
             """
-            connection = session.get(connection['href']).json()
+            connection = session.get('/connections/%s' % connection_id).json()
             if ConnectionState[connection['state']] in failed_states:
                 raise ConnectionOperationFailedException(connection=connection)
             if ConnectionState[connection['state']] != expected_state:
@@ -1082,25 +1030,24 @@ class Client(object):
 
         @staticmethod
         @retry(ConnectionOperationTimeoutException)
-        def __get_connection_until_not_found(session, connection, failed_states=[]):
+        def __get_connection_until_not_found(session, connection_id, failed_states):
             """
             Retrieve a connection until it no longer exists using an exponential backoff
             :param RelativeSession session: a :class:`Client`'s relative session
-            :param Connection connection: the connection
+            :param str connection_id: the connection id
             :param list[ConnectionState] failed_states: a list of failed states that instead
-                raise ConnectionOperationFailedException
             :raises: .exception.ConnectionOperationTimeoutException
             :raises: .exception.ConnectionOperationFailedException
             """
             try:
-                connection = session.get(connection['href']).json()
+                connection = session.get('/connections/%s' % connection_id).json()
             except NotFoundException:
                 return
             if ConnectionState[connection['state']] in failed_states:
                 raise ConnectionOperationFailedException(connection=connection)
             raise ConnectionOperationTimeoutException(connection=connection)
 
-        def get_by_id(self, connection_id):
+        def get(self, connection_id):
             """
             Get a connection with the provided connection id.
             :param str connection_id: the connection id
@@ -1108,15 +1055,6 @@ class Client(object):
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/connections/%s' % connection_id).json()
-
-        def get(self, connection):
-            """
-            Get a connection using the provided connection object.
-            :param Connection connection: the connection object
-            :rtype: Connection
-            :raises: .exception.HttpClientException
-            """
-            return self.__session.get(connection['href']).json()
 
         def update(self, connection, wait_until_active=False):
             """
@@ -1128,35 +1066,35 @@ class Client(object):
             :raises: .exception.ConnectionOperationTimeoutException
             :raises: .exception.ConnectionOperationFailedException
             """
-            connection = self.__session.put(connection['href'], json=connection).json()
+            connection = self.__session.put('/connections/%s' % connection['id'], json=connection).json()
             if wait_until_active:
                 return Client.ConnectionsClient.get_connection_until_state(
                     self.__session,
-                    connection,
+                    connection['id'],
                     ConnectionState.ACTIVE,
                     [ConnectionState.FAILED_TO_UPDATE]
                 )
             else:
                 return connection
 
-        def delete(self, connection, wait_until_deleted=False):
+        def delete(self, connection_id, wait_until_deleted=False):
             """
             Delete a connection.
-            :param Connection connection: the connection object
+            :param str connection_id: the connection id
             :param bool wait_until_deleted: wait until the connection is deleted using a backoff retry
             :raises: .exception.HttpClientException
             :raises: .exception.ConnectionOperationTimeoutException
             :raises: .exception.ConnectionOperationFailedException
             """
-            self.__session.delete(connection['href'])
+            self.__session.delete(connection_id)
             if wait_until_deleted:
                 Client.ConnectionsClient.__get_connection_until_not_found(
                     self.__session,
-                    connection,
+                    connection_id,
                     [ConnectionState.FAILED_TO_DELETE]
                 )
 
-        def get_tasks_by_id(self, connection_id):
+        def get_tasks(self, connection_id):
             """
             Get the tasks for a connection.
             :param str connection_id: the connection id
@@ -1165,24 +1103,15 @@ class Client(object):
             """
             return self.__session.get('/connections/%s/tasks' % connection_id).json()
 
-        def get_tasks(self, connection):
-            """
-            Get the tasks for a connection.
-            :param Connection connection: the connection
-            :rtype: list[Task]
-            :raises: .exception.HttpClientException
-            """
-            return self.__session.get('%s/tasks' % connection['href']).json()
-
-        def create_task(self, connection, task):
+        def create_task(self, connection_id, task):
             """
             Create a task for a connection.
-            :param Connection connection: the connection
+            :param str connection_id: the connection id
             :param Task task: the task
             :rtype: Task
             :raises: .exception.HttpClientException
             """
-            return self.__session.post('%s/tasks' % connection['href'], json=task).json()
+            return self.__session.post('/connections/%s/tasks' % connection_id, json=task).json()
 
     class FacilitiesClient(object):
         def __init__(self, session):
@@ -1200,7 +1129,7 @@ class Client(object):
             """
             return self.__session.get('/facilities').json()
 
-        def get_by_id(self, facility_id):
+        def get(self, facility_id):
             """
             Get a facility with the provided facility id.
             :param str facility_id: the facility id
@@ -1208,15 +1137,6 @@ class Client(object):
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/facilities/%s' % facility_id).json()
-
-        def get(self, facility):
-            """
-            Get a facility using the provided facility object.
-            :param Facility facility: the location object
-            :rtype: Facility
-            :raises: .exception.HttpClientException
-            """
-            return self.__session.get(facility['href']).json()
 
     class GatewaysClient(object):
         def __init__(self, session):
@@ -1226,7 +1146,7 @@ class Client(object):
             """
             self.__session = session
 
-        def get_by_id(self, gateway_id):
+        def get(self, gateway_id):
             """
             Get a gateway by its id
             :param str gateway_id: the gateway id
@@ -1235,16 +1155,7 @@ class Client(object):
             """
             return self.__session.get('/gateways/%s' % gateway_id).json()
 
-        def get_bgp_routes(self, gateway):
-            """
-            Get the bgp routes for a gateway.
-            :param Gateway gateway: the gateway
-            :rtype: list[BGPRoute]
-            :raises: .exception.HttpClientException
-            """
-            return self.__session.get('/gateways/%s/bgpRoutes' % gateway['id']).json()
-
-        def get_bgp_routes_by_id(self, gateway_id):
+        def get_bgp_routes(self, gateway_id):
             """
             Get the bgp routes for a gateway.
             :param str gateway_id: the gateway id
@@ -1253,17 +1164,7 @@ class Client(object):
             """
             return self.__session.get('/gateways/%s/bgpRoutes' % gateway_id).json()
 
-        def get_connectivity_over_time(self, gateway, date_filter):
-            """
-            Get the connectivity details for a gateway over time.
-            :param Gateway gateway: the gateway
-            :param DateFilter date_filter: a date filter consisting of 'gt', 'lt', 'gte', 'lte' properties
-            :rtype: list[ConnectivityByGateway]
-            :raises: .exception.HttpClientException
-            """
-            return self.__session.post('/gateways/%s/metrics/connectivity' % gateway['id'], json=date_filter).json()
-
-        def get_connectivity_over_time_by_id(self, gateway_id, date_filter):
+        def get_connectivity_over_time(self, gateway_id, date_filter):
             """
             Get the connectivity details for a gateway by id over time.
             :param str gateway_id: the gateway id
@@ -1273,16 +1174,7 @@ class Client(object):
             """
             return self.__session.post('/gateways/%s/metrics/connectivity' % gateway_id, json=date_filter).json()
 
-        def get_latest_connectivity(self, gateway):
-            """
-            Get the current connectivity details for a gateway.
-            :param Gateway gateway: the gateway
-            :rtype: ConnectivityByGateway
-            :raises: .exception.HttpClientException
-            """
-            return self.__session.get('/gateways/%s/metrics/connectivity/current' % gateway['id']).json()
-
-        def get_latest_connectivity_by_id(self, gateway_id):
+        def get_latest_connectivity(self, gateway_id):
             """
             Get the current connectivity details for a gateway by id.
             :param str gateway_id: the gateway id
@@ -1291,7 +1183,7 @@ class Client(object):
             """
             return self.__session.get('/gateways/%s/metrics/connectivity/current' % gateway_id).json()
 
-        def get_tasks_by_id(self, gateway_id):
+        def get_tasks(self, gateway_id):
             """
             Get the tasks for a gateway.
             :param str gateway_id: the gateway id
@@ -1300,16 +1192,7 @@ class Client(object):
             """
             return self.__session.get('/gateways/%s/tasks' % gateway_id).json()
 
-        def get_tasks(self, gateway):
-            """
-            Get the tasks for a gateway.
-            :param Gateway gateway: the gateway
-            :rtype: list[Task]
-            :raises: .exception.HttpClientException
-            """
-            return self.__session.get('/gateways/%s/tasks' % gateway['id']).json()
-
-        def create_task_by_id(self, gateway_id, task):
+        def create_task(self, gateway_id, task):
             """
             Create a task for a gateway.
             :param str gateway_id: the gateway id
@@ -1318,16 +1201,6 @@ class Client(object):
             :raises: .exception.HttpClientException
             """
             return self.__session.post('/gateways/%s/tasks' % gateway_id, json=task).json()
-
-        def create_task(self, gateway, task):
-            """
-            Create a task for a gateway.
-            :param Gateway gateway: the gateway
-            :param Task task: the task
-            :rtype: Task
-            :raises: .exception.HttpClientException
-            """
-            return self.__session.post('/gateways/%s/tasks' % gateway['id'], json=task).json()
 
     class LocationsClient(object):
         def __init__(self, session):
@@ -1345,7 +1218,7 @@ class Client(object):
             """
             return self.__session.get('/locations').json()
 
-        def get_by_id(self, location_id):
+        def get(self, location_id):
             """
             Get a location with the provided location id.
             :param str location_id: the location id
@@ -1353,15 +1226,6 @@ class Client(object):
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/locations/%s' % location_id).json()
-
-        def get(self, location):
-            """
-            Get a location using the provided location object.
-            :param Location location: the location object
-            :rtype: Location
-            :raises: .exception.HttpClientException
-            """
-            return self.__session.get(location['href']).json()
 
     class NetworksClient(object):
         def __init__(self, session):
@@ -1371,7 +1235,7 @@ class Client(object):
             """
             self.__session = session
 
-        def get_by_id(self, network_id):
+        def get(self, network_id):
             """
             Get a network with the provided network id.
             :param str network_id: the network id
@@ -1380,15 +1244,6 @@ class Client(object):
             """
             return self.__session.get('/networks/%s' % network_id).json()
 
-        def get(self, network):
-            """
-            Get a network with the provided network object.
-            :param Network network: the network object
-            :rtype: Network
-            :raises: .exception.HttpClientException
-            """
-            return self.__session.get(network['href']).json()
-
         def update(self, network):
             """
             Update a network.
@@ -1396,33 +1251,33 @@ class Client(object):
             :rtype: Network
             :raises: .exception.HttpClientException
             """
-            return self.__session.put(network['href'], json=network).json()
+            return self.__session.put('/networks/%s' % network['id'], json=network).json()
 
-        def delete(self, network):
+        def delete(self, network_id):
             """
             Delete a network.
-            :param Network network: the network object
+            :param str network_id: the network id
             :raises: .exception.HttpClientException
             """
-            self.__session.delete(network['href'])
+            self.__session.delete('/networks/%s' % network_id)
 
-        def connections(self, network):
+        def connections(self, network_id):
             """
             Get the account network connections client using the provided account.
-            :param Network network:
+            :param str network_id: the network id
             :rtype: Client.NetworkConnectionsClient
             """
-            return Client.NetworkConnectionsClient(self.__session, network)
+            return Client.NetworkConnectionsClient(self.__session, network_id)
 
     class NetworkConnectionsClient(object):
-        def __init__(self, session, network):
+        def __init__(self, session, network_id):
             """
             The Network Connections client
             :param RelativeSession session:
-            :param Network network:
+            :param str network_id:
             """
             self.__session = session
-            self.__network = network
+            self.__network_id = network_id
 
         def list(self):
             """
@@ -1430,7 +1285,7 @@ class Client(object):
             :rtype: list[Connection]
             :raises: .exception.HttpClientException
             """
-            return self.__session.get('%s/connections' % self.__network['href']).json()
+            return self.__session.get('/networks/%s/connections' % self.__network_id).json()
 
         def create(self, connection, wait_until_active=False):
             """
@@ -1442,11 +1297,11 @@ class Client(object):
             :raises: .exception.ConnectionOperationTimeoutException
             :raises: .exception.ConnectionOperationFailedException
             """
-            connection = self.__session.post('%s/connections' % self.__network['href'], json=connection).json()
+            connection = self.__session.post('/networks/%s/connections' % self.__network_id, json=connection).json()
             if wait_until_active:
                 return Client.ConnectionsClient.get_connection_until_state(
                     self.__session,
-                    connection,
+                    connection['id'],
                     ConnectionState.ACTIVE,
                     [ConnectionState.FAILED_TO_PROVISION]
                 )
@@ -1480,7 +1335,7 @@ class Client(object):
             """
             self.__session = session
 
-        def get_by_id(self, port_id):
+        def get(self, port_id):
             """
             Get the port with the provided port id.
             :param str port_id: the port id
@@ -1489,7 +1344,7 @@ class Client(object):
             """
             return self.__session.get('/ports/%s' % port_id).json()
 
-        def get_accounts_using_port_by_id(self, port_id):
+        def get_accounts_using_port(self, port_id):
             """
             Get the accounts using the port with the provided port id.
             :param str port_id: the port id
@@ -1498,15 +1353,6 @@ class Client(object):
             """
             return self.__session.get('/ports/%s/accounts' % port_id).json()
 
-        def get(self, port):
-            """
-            Get the port using the provided port.
-            :param Port port: the port object
-            :rtype: Port
-            :raises: .exception.HttpClientException
-            """
-            return self.__session.get(port['href']).json()
-
         def update(self, port):
             """
             Update a port.
@@ -1514,15 +1360,15 @@ class Client(object):
             :rtype: Port
             :raises: .exception.HttpClientException
             """
-            return self.__session.put(port['href'], json=port).json()
+            return self.__session.put('/ports/%s' % port['id'], json=port).json()
 
-        def delete(self, port):
+        def delete(self, port_id):
             """
             Delete a port.
-            :param Port port: the port object
+            :param str port_id: the port id
             :raises: .exception.HttpClientException
             """
-            self.__session.delete(port['href'])
+            self.__session.delete('/ports/%s' % port_id)
 
     class SupportedConnectionsClient(object):
         def __init__(self, session):
@@ -1532,7 +1378,7 @@ class Client(object):
             """
             self.__session = session
 
-        def get_by_id(self, supported_connection_id):
+        def get(self, supported_connection_id):
             """
             Get the supported connection with the provided supported connection id.
             :param str supported_connection_id: the supported connection id
@@ -1540,15 +1386,6 @@ class Client(object):
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/supportedConnections/%s' % supported_connection_id).json()
-
-        def get(self, supported_connection):
-            """
-            Get the supported connection using the provided supported connection.
-            :param SupportedConnection supported_connection: the supported connection object
-            :rtype: SupportedConnection
-            :raises: .exception.HttpClientException
-            """
-            return self.__session.get(supported_connection['href']).json()
 
     class TasksClient(object):
         def __init__(self, session):
@@ -1567,7 +1404,7 @@ class Client(object):
             """
             return self.__session.get('/tasks', params={'state': state}).json()
 
-        def get_by_id(self, task_id):
+        def get(self, task_id):
             """
             Get a task by it's id.
             :param str task_id: the task id
@@ -1575,12 +1412,3 @@ class Client(object):
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/tasks/%s' % task_id).json()
-
-        def get(self, task):
-            """
-            Get the task using the provided task.
-            :param Task task: the task object
-            :rtype: SupportedConnection
-            :raises: .exception.HttpClientException
-            """
-            return self.__session.get(task['href']).json()

--- a/pureport/api/client.py
+++ b/pureport/api/client.py
@@ -1015,8 +1015,8 @@ class Client(object):
             Retrieve a connection until it enters a certain state using an exponential backoff
             :param RelativeSession session: a :class:`Client`'s relative session
             :param str connection_id: the connection id
-            :param ConnectionState expected_state: the expected state
-            :param list[ConnectionState] failed_states: a list of failed states that instead
+            :param ConnectionState|str expected_state: the expected state
+            :param list[ConnectionState|str] failed_states: a list of failed states that instead
             :rtype: Connection
             :raises: .exception.ConnectionOperationTimeoutException
             :raises: .exception.ConnectionOperationFailedException
@@ -1035,7 +1035,7 @@ class Client(object):
             Retrieve a connection until it no longer exists using an exponential backoff
             :param RelativeSession session: a :class:`Client`'s relative session
             :param str connection_id: the connection id
-            :param list[ConnectionState] failed_states: a list of failed states that instead
+            :param list[ConnectionState|str] failed_states: a list of failed states that instead
             :raises: .exception.ConnectionOperationTimeoutException
             :raises: .exception.ConnectionOperationFailedException
             """

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ def read_requirements(file_name):
 
 setup(
     name='pureport-client',
-    version='0.0.9',
+    version='1.0.0',
     author='Pureport',
     author_email='noreply@pureport.com',
     license='MIT',


### PR DESCRIPTION
Removes references to `href` when building URLs, e.g. most functions now require passing the `id` of an object for GET/DELETE.  For PUT update functions, it will use the correct field within the object to build the url string.  This removes some of the duplication we had with functions, like `get_by_id` and a `get` call that did the same thing.  While it was somewhat nice to support both methods, it's fairly redundant and in terms of supporting something like a CLI (which I believe we intend to do at some point), make's it harder when parameters are not primitives.

I'm thinking this might be a major version bump.

I'd also like to get some testing around this stuff (even though it's very basic), but I think we should have a discussion on how that should be done.