### PR TITLE
Use tox and update namespace packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 *.swp
 *.iml
 *.egg-info/
+.tox/
 build/
 dist/
+venv/
 __pycache__

--- a/.jenkins/Dockerfile
+++ b/.jenkins/Dockerfile
@@ -1,2 +1,5 @@
 FROM python:3
-RUN pip install flake8 twine
+RUN pip install \
+      tox \
+      virtualenv \
+      twine

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -4,7 +4,7 @@ pipeline {
         stage('Lint') {
             steps {
                 sh """
-                    flake8
+                    tox
                 """
             }
         }

--- a/pureport/__init__.py
+++ b/pureport/__init__.py
@@ -1,2 +1,0 @@
-# -*- coding: utf-8 -*-
-__import__('pkg_resources').declare_namespace(__name__)

--- a/pureport/api/__init__.py
+++ b/pureport/api/__init__.py
@@ -1,2 +1,0 @@
-# -*- coding: utf-8 -*-
-__import__('pkg_resources').declare_namespace(__name__)

--- a/pureport/api/client.py
+++ b/pureport/api/client.py
@@ -755,7 +755,10 @@ class Client(object):
             :rtype: AccountMember
             :raises: .exception.HttpClientException
             """
-            return self.__session.put('%s/members/%s' % (self.__account['href'], member['user']['id']), json=member).json()
+            return self.__session.put(
+                '%s/members/%s' % (self.__account['href'], member['user']['id']),
+                json=member
+            ).json()
 
         def delete(self, member):
             """
@@ -791,7 +794,10 @@ class Client(object):
             :rtype: list[ConnectionTimeEgressIngress]
             :raises: .exception.HttpClientException
             """
-            return self.__session.post('%s/metrics/usageByConnectionAndTime' % self.__account['href'], json=options).json()
+            return self.__session.post(
+                '%s/metrics/usageByConnectionAndTime' % self.__account['href'],
+                json=options
+            ).json()
 
         def usage_by_network_and_time(self, options):
             """

--- a/pureport/exception/__init__.py
+++ b/pureport/exception/__init__.py
@@ -1,2 +1,0 @@
-# -*- coding: utf-8 -*-
-__import__('pkg_resources').declare_namespace(__name__)

--- a/pureport/util/__init__.py
+++ b/pureport/util/__init__.py
@@ -1,2 +1,0 @@
-# -*- coding: utf-8 -*-
-__import__('pkg_resources').declare_namespace(__name__)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+enum34
+requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[flake8]
-max-line-length = 140

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,24 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup, find_namespace_packages
 
+
+def read_file(file_name):
+    """Read file and return its contents."""
+    with open(file_name, 'r') as f:
+        return f.read()
+
+
+def read_requirements(file_name):
+    """Read requirements file as a list."""
+    reqs = read_file(file_name).splitlines()
+    if not reqs:
+        raise RuntimeError(
+            "Unable to read requirements from the %s file"
+            % file_name
+        )
+    return reqs
+
+
 setup(
     name='pureport-client',
     version='0.0.9',
@@ -17,10 +35,7 @@ setup(
         'pureport.exception.*',
         'pureport.util.*'
     ]),
-    install_requires=[
-        'requests',
-        'enum34'
-    ],
+    install_requires=read_requirements('requirements.txt'),
     classifiers=[
         'Programming Language :: Python :: 3',
         'Operating System :: OS Independent',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-from setuptools import setup, find_packages
+from setuptools import setup, find_namespace_packages
 
 setup(
     name='pureport-client',
@@ -11,20 +11,18 @@ setup(
     long_description=open('README.md', 'r').read(),
     long_description_content_type='text/markdown',
     url='https://github.com/pureport/pureport-python-client',
-    packages=find_packages(),
-    namespace_packages=[
-        'pureport',
-        'pureport.api',
-        'pureport.exception',
-        'pureport.util'
-    ],
+    packages=find_namespace_packages(include=[
+        'pureport.*',
+        'pureport.api.*',
+        'pureport.exception.*',
+        'pureport.util.*'
+    ]),
     install_requires=[
         'requests',
         'enum34'
     ],
     classifiers=[
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 2',
         'Operating System :: OS Independent',
     ]
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,4 @@
+flake8
+pylint
+pytest
+tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+skipsdist = True
+envlist = flake8
+
+[testenv]
+deps =
+    -rrequirements.txt
+    -rtest-requirements.txt
+commands = pytest {posargs}
+
+[testenv:flake8]
+deps = flake8
+commands = flake8 pureport
+
+[flake8]
+max-line-length = 140

--- a/tox.ini
+++ b/tox.ini
@@ -13,4 +13,4 @@ deps = flake8
 commands = flake8 pureport
 
 [flake8]
-max-line-length = 140
+max-line-length = 120


### PR DESCRIPTION
- Uses [tox](https://tox.readthedocs.io/en/latest/) for running any testing aspects of the build
- Switches to Python 3 [native namespace packages](https://packaging.python.org/guides/packaging-namespace-packages/#native-namespace-packages), e.g. no __init__.py and using find_namespace_packages in the setup.py file.  This effectively removes support for Python 2 and I've changed the package classifiers to suggest that is the case.