### PR TITLE
Add a cli to expose all commands to the terminal.

### DIFF
--- a/pureport/api/client.py
+++ b/pureport/api/client.py
@@ -1,4 +1,6 @@
 # -*- coding: utf-8 -*-
+from click import Choice, argument, option
+from click_params import JSON
 from enum import Enum
 from ..exception.api import \
     ConnectionOperationFailedException, \
@@ -23,6 +25,7 @@ AccountConsent = dict
 AccountInvite = dict
 AccountMember = dict
 AccountPermissions = dict
+AccountRole = dict
 AuditEntry = dict
 APIKey = dict
 BGPRoute = dict
@@ -116,6 +119,7 @@ class Client(object):
     def accounts(self):
         """
         The accounts client
+        \f
         :rtype: Client.AccountsClient
         """
         return self.AccountsClient(self.__session)
@@ -124,6 +128,7 @@ class Client(object):
     def cloud_regions(self):
         """
         The cloud regions client
+        \f
         :rtype: Client.CloudRegionsClient
         """
         return Client.CloudRegionsClient(self.__session)
@@ -132,6 +137,7 @@ class Client(object):
     def cloud_services(self):
         """
         The cloud services client
+        \f
         :rtype: Client.CloudServicesClient
         """
         return Client.CloudServicesClient(self.__session)
@@ -140,6 +146,7 @@ class Client(object):
     def connections(self):
         """
         The connections client
+        \f
         :rtype: Client.ConnectionsClient
         """
         return Client.ConnectionsClient(self.__session)
@@ -148,6 +155,7 @@ class Client(object):
     def facilities(self):
         """
         The facilities client
+        \f
         :rtype: Client.FacilitiesClient
         """
         return Client.FacilitiesClient(self.__session)
@@ -156,6 +164,7 @@ class Client(object):
     def gateways(self):
         """
         The gateways client
+        \f
         :rtype: Client.GatewaysClient
         """
         return Client.GatewaysClient(self.__session)
@@ -164,6 +173,7 @@ class Client(object):
     def locations(self):
         """
         The locations client
+        \f
         :rtype: Client.LocationsClient
         """
         return Client.LocationsClient(self.__session)
@@ -172,6 +182,7 @@ class Client(object):
     def networks(self):
         """
         The networks client
+        \f
         :rtype: Client.NetworksClient
         """
         return Client.NetworksClient(self.__session)
@@ -180,6 +191,7 @@ class Client(object):
     def options(self):
         """
         The options client
+        \f
         :rtype: Client.OptionsClient
         """
         return Client.OptionsClient(self.__session)
@@ -188,6 +200,7 @@ class Client(object):
     def ports(self):
         """
         The ports client
+        \f
         :rtype: Client.PortsClient
         """
         return Client.PortsClient(self.__session)
@@ -196,6 +209,7 @@ class Client(object):
     def supported_connections(self):
         """
         The supported connections client
+        \f
         :rtype: Client.SupportedConnectionsClient
         """
         return Client.SupportedConnectionsClient(self.__session)
@@ -204,6 +218,7 @@ class Client(object):
     def tasks(self):
         """
         The tasks client
+        \f
         :rtype: Client.TasksClient
         """
         return Client.TasksClient(self.__session)
@@ -216,9 +231,15 @@ class Client(object):
             """
             self.__session = session
 
+        @option('-i', '--ids', multiple=True,
+                help='Find a particular set of accounts by their ids.')
+        @option('-p', '--parent_id', help='Find all children accounts of a single parent account.')
+        @option('-n', '--name', help='Search for accounts by their name.')
+        @option('-l', '--limit', type=int, help='Limit the number of results.')
         def list(self, ids=None, parent_id=None, name=None, limit=None):
             """
             Get a list of all accounts.
+            \f
             :param list[str] ids: a list of account ids to find
             :param str parent_id: a parent account id
             :param str name: a name for lowercase inter-word checking
@@ -235,156 +256,194 @@ class Client(object):
                     'limit': limit
                 }).json()
 
+        @argument('account_id')
         def get(self, account_id):
             """
             Get an account by its id.
+            \f
             :param str account_id: the account id
             :rtype: Account
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/accounts/%s' % account_id).json()
 
+        @argument('account', type=JSON)
         def create(self, account):
             """
             Create an account.
+            \f
             :param Account account: the account object
             :rtype: Account
             :raises: .exception.HttpClientException
             """
             return self.__session.post('/accounts', json=account).json()
 
+        @argument('account', type=JSON)
         def update(self, account):
             """
             Update an account.
+            \f
             :param Account account: the account object
             :rtype: Account
             :raises: .exception.HttpClientException
             """
             return self.__session.put('/accounts/%s' % account['id'], json=account).json()
 
+        @argument('account_id')
         def delete(self, account_id):
             """
             Delete an account.
+            \f
             :param str account_id: the account id
             :raises: .exception.HttpClientException
             """
             self.__session.delete('/accounts/%s' % account_id)
 
+        @argument('account_id')
         def api_keys(self, account_id):
             """
-            Get the account api keys client using the provided account.
+            The account api keys client
+            \f
             :param str account_id: the account id
             :rtype: Client.AccountAPIKeysClient
             """
             return Client.AccountAPIKeysClient(self.__session, account_id)
 
+        @argument('account_id')
         def audit_log(self, account_id):
             """
-            Get the account audit log client using the provided account.
+            The account audit log client
+            \f
             :param str account_id: the account id
             :rtype: Client.AccountAuditLogClient
             """
             return Client.AccountAuditLogClient(self.__session, account_id)
 
+        @argument('account_id')
         def billing(self, account_id):
             """
-            Get the account billing client using the provided account.
+            The account billing client
+            \f
             :param str account_id: the account id
             :rtype: Client.AccountBillingClient
             """
             return Client.AccountBillingClient(self.__session, account_id)
 
+        @argument('account_id')
         def connections(self, account_id):
             """
-            Get the account connections client using the provided account.
+            The account connections client
+            \f
             :param str account_id: the account id
             :rtype: Client.AccountConnectionsClient
             """
             return Client.AccountConnectionsClient(self.__session, account_id)
 
+        @argument('account_id')
         def consent(self, account_id):
             """
-            Get the account consent client using the provided account.
+            The account consent client
+            \f
             :param str account_id: the account id
             :rtype: Client.AccountConsentClient
             """
             return Client.AccountConsentClient(self.__session, account_id)
 
+        @argument('account_id')
         def invites(self, account_id):
             """
-            Get the account invites client using the provided account.
+            The account invites client
+            \f
             :param str account_id: the account id
             :rtype: Client.AccountInvitesClient
             """
             return Client.AccountInvitesClient(self.__session, account_id)
 
+        @argument('account_id')
         def invoices(self, account_id):
             """
-            Get the account invoices client using the provided account.
+            The account invoices client
+            \f
             :param str account_id: the account id
             :rtype: Client.AccountInvoicesClient
             """
             return Client.AccountInvoicesClient(self.__session, account_id)
 
+        @argument('account_id')
         def members(self, account_id):
             """
-            Get the account members client using the provided account.
+            The account members client
+            \f
             :param str account_id: the account id
             :rtype: Client.AccountMembersClient
             """
             return Client.AccountMembersClient(self.__session, account_id)
 
+        @argument('account_id')
         def metrics(self, account_id):
             """
-            Get the account metrics client using the provided account.
+            The account metrics client
+            \f
             :param str account_id: the account id
             :rtype: Client.AccountMetricsClient
             """
             return Client.AccountMetricsClient(self.__session, account_id)
 
+        @argument('account_id')
         def networks(self, account_id):
             """
-            Get the account networks client using the provided account.
+            The account networks client
+            \f
             :param str account_id: the account id
             :rtype: Client.AccountNetworksClient
             """
             return Client.AccountNetworksClient(self.__session, account_id)
 
+        @argument('account_id')
         def permissions(self, account_id):
             """
-            Get the account permissions client using the provided account.
+            The account permissions client
+            \f
             :param str account_id: the account id
             :rtype: Client.AccountPermissionsClient
             """
             return Client.AccountPermissionsClient(self.__session, account_id)
 
+        @argument('account_id')
         def ports(self, account_id):
             """
-            Get the account ports client using the provided account.
+            The account ports client
+            \f
             :param str account_id: the account id
             :rtype: Client.AccountPortsClient
             """
             return Client.AccountPortsClient(self.__session, account_id)
 
+        @argument('account_id')
         def roles(self, account_id):
             """
-            Get the account roles client using the provided account.
+            The account roles client
+            \f
             :param str account_id: the account id
             :rtype: Client.AccountRolesClient
             """
             return Client.AccountRolesClient(self.__session, account_id)
 
+        @argument('account_id')
         def supported_connections(self, account_id):
             """
-            Get the account supported connections client using the provided account.
+            The account supported connections client
+            \f
             :param str account_id: the account id
             :rtype: Client.AccountSupportedConnectionsClient
             """
             return Client.AccountSupportedConnectionsClient(self.__session, account_id)
 
+        @argument('account_id')
         def supported_ports(self, account_id):
             """
-            Get the account supported ports client using the provided account.
+            The account supported ports client
+            \f
             :param str account_id: the account id
             :rtype: Client.AccountSupportedConnectionsClient
             """
@@ -403,32 +462,39 @@ class Client(object):
         def list(self):
             """
             Get a list of all API keys for an account.
+            \f
             :rtype: list[APIKey]
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/accounts/%s/apikeys' % self.__account_id).json()
 
+        @argument('api_key_key')
         def get(self, api_key_key):
             """
             Get an account's API Key with the provided API Key key.
+            \f
             :param str api_key_key: the key of an API Key
             :rtype: APIKey
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/accounts/%s/apikeys/%s' % (self.__account_id, api_key_key)).json()
 
+        @argument('api_key', type=JSON)
         def create(self, api_key):
             """
             Create an API Key for the provided account.
+            \f
             :param APIKey api_key: the APIKey object
             :rtype: APIKey
             :raises: .exception.HttpClientException
             """
             return self.__session.post('/accounts/%s/apikeys' % self.__account_id, json=api_key).json()
 
+        @argument('api_key', type=JSON)
         def update(self, api_key):
             """
             Update an API Key for the provided account.
+            \f
             :param APIKey api_key: the APIKey object
             :rtype: APIKey
             :raises: .exception.HttpClientException
@@ -438,9 +504,11 @@ class Client(object):
                 json=api_key
             ).json()
 
+        @argument('api_key_key')
         def delete(self, api_key_key):
             """
             Delete an API Key from the provided account.
+            \f
             :param str api_key_key: the APIKey key name
             :raises: .exception.HttpClientException
             """
@@ -456,12 +524,61 @@ class Client(object):
             self.__session = session
             self.__account_id = account_id
 
+        @option('-pn', '--page_number', type=int, help='The page number for pagination.')
+        @option('-ps', '--page_size', type=int, help='The page size for pagination.')
+        @option('-s', '--sort', type=Choice(['timestamp', 'eventType', 'subjectType',
+                                             'ipAddress', 'userAgent', 'source', 'result']),
+                help='How should the data be sorted.')
+        @option('-sd', '--sort_direction', type=Choice(['ASC', 'DESC']),
+                help='The direction the results will be sorted.')
+        @option('-st', '--start_time',
+                help='The start time for selecting results between a time range.')
+        @option('-et', '--end_time',
+                help='The end time for selecting results between a time range.')
+        @option('-i', '--include_child_accounts', is_flag=True,
+                help='If the results should include entries from child accounts.')
+        @option('-ev', '--event_types', type=Choice(['USER_LOGIN', 'USER_FORGOT_PASSWORD', 'API_LOGIN',
+                                                     'ACCOUNT_CREATE', 'ACCOUNT_UPDATE', 'ACCOUNT_DELETE',
+                                                     'ACCOUNT_BILLING_CREATE', 'ACCOUNT_BILLING_UPDATE',
+                                                     'ACCOUNT_BILLING_DELETE', 'NETWORK_CREATE',
+                                                     'NETWORK_UPDATE', 'NETWORK_DELETE', 'CONNECTION_CREATE',
+                                                     'CONNECTION_UPDATE', 'CONNECTION_DELETE',
+                                                     'GATEWAY_CREATE', 'GATEWAY_UPDATE', 'GATEWAY_DELETE',
+                                                     'API_KEY_CREATE', 'API_KEY_UPDATE', 'API_KEY_DELETE',
+                                                     'ROLE_CREATE', 'ROLE_UPDATE', 'ROLE_DELETE', 'USER_CREATE',
+                                                     'USER_UPDATE', 'USER_DELETE', 'USER_DOMAIN_CREATE',
+                                                     'USER_DOMAIN_UPDATE', 'USER_DOMAIN_DELETE', 'PORT_CREATE',
+                                                     'PORT_UPDATE', 'PORT_DELETE', 'MEMBER_INVITE_CREATE',
+                                                     'MEMBER_INVITE_ACCEPT', 'MEMBER_INVITE_UPDATE',
+                                                     'MEMBER_INVITE_DELETE', 'ACCOUNT_MEMBER_CREATE',
+                                                     'ACCOUNT_MEMBER_UPDATE', 'ACCOUNT_MEMBER_DELETE',
+                                                     'CONNECTION_STATE_CHANGE', 'GATEWAY_STATE_CHANGE',
+                                                     'GATEWAY_BGP_STATUS_CHANGE', 'GATEWAY_IPSEC_STATUS_CHANGE',
+                                                     'NOTIFICATION_CREATE', 'NOTIFICATION_UPDATE',
+                                                     'NOTIFICATION_DELETE', 'TASK_CREATE',
+                                                     'TASK_UPDATE', 'TASK_DELETE']),
+                help='Limit the results to particular event types.')
+        @option('-r', '--result', type=Choice(['true', 'false']),
+                help='If the result was successful or not.')
+        @option('-pi', '--principal_id',
+                help='The principal id, e.g. user or api key id.')
+        @option('-ci', '--correlation_id',
+                help='The correlation id, e.g. id of audit event to surface related events.')
+        @option('-si', '--subject_id',
+                help='The subject id, e.g. id of audit subject '
+                     '(connection, network, etc.) to surface related events.')
+        @option('-su', '--subject_type', type=Choice(['ACCOUNT', 'CONNECTION', 'NETWORK', 'USER',
+                                                      'USER_DOMAIN', 'ROLE', 'API_KEY', 'GATEWAY',
+                                                      'NOTIFICATION', 'ACCOUNT_INVITE', 'ACCOUNT_BILLING',
+                                                      'PORT', 'ACCOUNT_MEMBER', 'TASK']),
+                help='The subject type')
         def query(self, page_number=None, page_size=None, sort=None, sort_direction=None,
                   start_time=None, end_time=None, include_child_accounts=None, event_types=None,
                   result=None, principal_id=None, ip_address=None, correlation_id=None, subject_id=None,
                   subject_type=None):
             """
             Query the audit log for this account.
+            \f
             :param int page_number:
             :param int page_size:
             :param str sort:
@@ -512,7 +629,9 @@ class Client(object):
         def get(self):
             """
             Get the billing information for the provided account.  This does not check parent
-            accounts.  If you want to find if any billing is configured, instead use
+            accounts.
+            \f
+            If you want to find if any billing is configured, instead use
             :func:`Client.AccountBillingClient.get_configured`.
             :rtype: AccountBilling
             :raises: .exception.HttpClientException
@@ -523,23 +642,28 @@ class Client(object):
             """
             Get the billing information for the provided account.  This returns the billing info of the
             account or any parent account.
-            :rtype: AccountBilling
+            \f
+            :rtype: bool
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/accounts/%s/billing/configured' % self.__account_id).json()
 
+        @argument('account_billing', type=JSON)
         def create(self, account_billing):
             """
             Add a payment method to provided account.
+            \f
             :param AccountBilling account_billing: the AccountBilling object
             :rtype: AccountBilling
             :raises: .exception.HttpClientException
             """
             return self.__session.post('/accounts/%s/billing' % self.__account_id, json=account_billing).json()
 
+        @argument('account_billing', type=JSON)
         def update(self, account_billing):
             """
             Update the payment method for the provided account.
+            \f
             :param AccountBilling account_billing: the AccountBilling object
             :rtype: AccountBilling
             :raises: .exception.HttpClientException
@@ -549,6 +673,7 @@ class Client(object):
         def delete(self):
             """
             Delete the current AccountBilling object from the account if it exists.
+            \f
             :raises: .exception.HttpClientException
             """
             self.__session.delete('/accounts/%s/billing' % self.__account_id)
@@ -566,6 +691,7 @@ class Client(object):
         def list(self):
             """
             Get all connections for the provided account.
+            \f
             :rtype: list[Connection]
             :raises: .exception.HttpClientException
             """
@@ -584,6 +710,7 @@ class Client(object):
         def get(self):
             """
             Get the consent information for the provided account.
+            \f
             :rtype: AccountConsent
             :raises: .exception.HttpClientException
             """
@@ -592,6 +719,7 @@ class Client(object):
         def accept(self):
             """
             Accept consent for the provided account.
+            \f
             :rtype: AccountConsent
             :raises: .exception.HttpClientException
             """
@@ -610,32 +738,39 @@ class Client(object):
         def list(self):
             """
             Get all invites for the provided account.
+            \f
             :rtype: list[AccountInvite]
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/accounts/%s/invites' % self.__account_id).json()
 
+        @argument('invite_id')
         def get(self, invite_id):
             """
             Get an account's invite with the provided account invite id.
+            \f
             :param str invite_id: the account invite id
             :rtype: AccountInvite
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/accounts/%s/invites/%s' % (self.__account_id, invite_id)).json()
 
+        @argument('invite', type=JSON)
         def create(self, invite):
             """
             Create an account invite using the provided account.
+            \f
             :param AccountInvite invite: the account invite object
             :rtype: AccountInvite
             :raises: .exception.HttpClientException
             """
             return self.__session.post('/accounts/%s/invites' % self.__account_id, json=invite).json()
 
+        @argument('invite', type=JSON)
         def update(self, invite):
             """
             Update an account invite using the provided account.
+            \f
             :param AccountInvite invite: the account invite object
             :rtype: AccountInvite
             :raises: .exception.HttpClientException
@@ -645,9 +780,11 @@ class Client(object):
                 json=invite
             ).json()
 
+        @argument('invite_id')
         def delete(self, invite_id):
             """
             Delete an account invite using the provided account.
+            \f
             :param str invite_id: the account invite id
             :raises: .exception.HttpClientException
             """
@@ -663,9 +800,11 @@ class Client(object):
             self.__session = session
             self.__account_id = account_id
 
+        @argument('invoice_filter', type=JSON)
         def list(self, invoice_filter):
             """
             List all invoices for an account.
+            \f
             :param dict invoice_filter: a filter object that matches Stripe's invoice filter
                 https://stripe.com/docs/api/invoices/list
             :rtype: list[NetworkInvoice]
@@ -676,6 +815,7 @@ class Client(object):
         def list_upcoming(self):
             """
             List all upcoming invoices for an account.
+            \f
             :rtype: list[NetworkInvoice]
             :raises: .exception.HttpClientException
             """
@@ -694,33 +834,41 @@ class Client(object):
         def list(self):
             """
             List all members for the provided account.
+            \f
             :rtype: list[AccountMember]
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/accounts/%s/members' % self.__account_id).json()
 
+        @argument('user_id')
         def get(self, user_id):
             """
             Get a member by their user id for the provided account.
+            \f
             :param str user_id: a user id
             :rtype: AccountMember
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/accounts/%s/members/%s' % (self.__account_id, user_id)).json()
 
+        @argument('member', type=JSON)
         def create(self, member):
             """
-            Create an member for the provided account.  It may be better to use the
-            :func:`Client.AccountInvite.post` if the user does or does not exist.
+            Create an member for the provided account.
+            \f
+            It may be better to use the :func:`Client.AccountInvite.post` if the
+            user does or does not exist.
             :param AccountMember member:  the account member object
             :rtype: AccountMember
             :raises: .exception.HttpClientException
             """
             return self.__session.post('%s/members' % self.__account_id, json=member).json()
 
+        @argument('member', type=JSON)
         def update(self, member):
             """
             Update a member for the provided account.
+            \f
             :param AccountMember member:  the account member object
             :rtype: AccountMember
             :raises: .exception.HttpClientException
@@ -730,9 +878,11 @@ class Client(object):
                 json=member
             ).json()
 
+        @argument('user_id')
         def delete(self, user_id):
             """
             Delete a member from the provided account.
+            \f
             :param str user_id: a user id
             :raises: .exception.HttpClientException
             """
@@ -748,9 +898,11 @@ class Client(object):
             self.__session = session
             self.__account_id = account_id
 
+        @argument('options', type=JSON)
         def usage_by_connection(self, options):
             """
             Retrieve egress/ingress total usage by connections
+            \f
             :param UsageByConnectionOptions options:
             :rtype: list[NetworkConnectionEgressIngress]
             :raises: .exception.HttpClientException
@@ -760,9 +912,11 @@ class Client(object):
                 json=options
             ).json()
 
+        @argument('options', type=JSON)
         def usage_by_connection_and_time(self, options):
             """
             Retrieve usage by a single connection over time
+            \f
             :param UsageByConnectionAndTimeOptions options:
             :rtype: list[ConnectionTimeEgressIngress]
             :raises: .exception.HttpClientException
@@ -772,9 +926,11 @@ class Client(object):
                 json=options
             ).json()
 
+        @argument('options', type=JSON)
         def usage_by_network_and_time(self, options):
             """
             Retrieve usage of networks over time
+            \f
             :param UsageByNetworkAndTimeOptions options:
             :rtype: list[NetworkTimeUsage]
             :raises: .exception.HttpClientException
@@ -797,14 +953,17 @@ class Client(object):
         def list(self):
             """
             Get all networks for the provided account.
+            \f
             :rtype: list[Network]
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/accounts/%s/networks' % self.__account_id).json()
 
+        @argument('network', type=JSON)
         def create(self, network):
             """
             Create a network for the provided account.
+            \f
             :param Network network:  the network object
             :rtype: Network
             :raises: .exception.HttpClientException
@@ -825,6 +984,7 @@ class Client(object):
             """
             Get all permissions for the provided account.  This returns the effect permission set for the
             currently logged in API Key.
+            \f
             :rtype: AccountPermissions
             :raises: .exception.HttpClientException
             """
@@ -843,14 +1003,17 @@ class Client(object):
         def list(self):
             """
             Get all ports for the provided account.
+            \f
             :rtype: list[Port]
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/accounts/%s/ports' % self.__account_id).json()
 
+        @argument('port', type=JSON)
         def create(self, port):
             """
             Create a port for the provided account.
+            \f
             :param Port port:  the port object
             :rtype: Port
             :raises: .exception.HttpClientException
@@ -870,41 +1033,50 @@ class Client(object):
         def list(self):
             """
             List all roles for the provided account.
+            \f
             :rtype: list[AccountRole]
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/accounts/%s/roles' % self.__account_id).json()
 
+        @argument('role_id')
         def get(self, role_id):
             """
             Get a role by its id for the provided account.
+            \f
             :param str role_id: the role id
             :rtype: AccountRole
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/accounts/%s/roles/%s' % (self.__account_id, role_id)).json()
 
+        @argument('role', type=JSON)
         def create(self, role):
             """
             Create a role for the provided account.
+            \f
             :param AccountRole role: the account role object
             :rtype: AccountRole
             :raises: .exception.HttpClientException
             """
             return self.__session.post('/accounts/%s/roles' % self.__account_id, json=role).json()
 
+        @argument('role', type=JSON)
         def update(self, role):
             """
             Update a role for the provided account.
+            \f
             :param AccountRole role: the account role object
             :rtype: AccountRole
             :raises: .exception.HttpClientException
             """
             return self.__session.put('%s/roles/%s' % (self.__account_id, role['id']), json=role).json()
 
+        @argument('role_id')
         def delete(self, role_id):
             """
             Update a role for the provided account.
+            \f
             :param str role_id: the role id
             :raises: .exception.HttpClientException
             """
@@ -923,6 +1095,7 @@ class Client(object):
         def list(self):
             """
             Get the supported connections for the provided account.
+            \f
             :rtype: list[SupportedConnection]
             :raises: .exception.HttpClientException
             """
@@ -938,9 +1111,11 @@ class Client(object):
             self.__session = session
             self.__account_id = account_id
 
+        @argument('facility_id')
         def list(self, facility_id):
             """
             Get the supported ports for the provided account.
+            \f
             :param str facility_id: the facility id to list supported ports for
             :rtype: list[SupportedPort]
             :raises: .exception.HttpClientException
@@ -961,14 +1136,17 @@ class Client(object):
         def list(self):
             """
             Get all available cloud regions.
+            \f
             :rtype: list[CloudRegion]
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/cloudRegions').json()
 
+        @argument('cloud_region_id')
         def get(self, cloud_region_id):
             """
             Get the cloud region with the provided cloud region id.
+            \f
             :param str cloud_region_id: the cloud region id
             :rtype: CloudRegion
             :raises: .exception.HttpClientException
@@ -986,14 +1164,17 @@ class Client(object):
         def list(self):
             """
             Get all available cloud services.
+            \f
             :rtype: list[CloudRegion]
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/cloudServices').json()
 
+        @argument('cloud_service_id')
         def get(self, cloud_service_id):
             """
             Get the cloud service with the provided cloud service id.
+            \f
             :param str cloud_service_id: the cloud service id
             :rtype: CloudRegion
             :raises: .exception.HttpClientException
@@ -1047,18 +1228,24 @@ class Client(object):
                 raise ConnectionOperationFailedException(connection=connection)
             raise ConnectionOperationTimeoutException(connection=connection)
 
+        @argument('connection_id')
         def get(self, connection_id):
             """
             Get a connection with the provided connection id.
+            \f
             :param str connection_id: the connection id
             :rtype: Connection
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/connections/%s' % connection_id).json()
 
+        @argument('connection')
+        @option('-w', '--wait_until_active', is_flag=True,
+                help='Wait until the connection is active.')
         def update(self, connection, wait_until_active=False):
             """
             Updated a connection.
+            \f
             :param Connection connection: the connection object
             :param bool wait_until_active: wait until the connection is active using a backoff retry
             :rtype: Connection
@@ -1077,9 +1264,13 @@ class Client(object):
             else:
                 return connection
 
+        @argument('connection_id')
+        @option('-w', '--wait_until_deleted', is_flag=True,
+                help='Wait until the connection is deleted.')
         def delete(self, connection_id, wait_until_deleted=False):
             """
             Delete a connection.
+            \f
             :param str connection_id: the connection id
             :param bool wait_until_deleted: wait until the connection is deleted using a backoff retry
             :raises: .exception.HttpClientException
@@ -1094,18 +1285,23 @@ class Client(object):
                     [ConnectionState.FAILED_TO_DELETE]
                 )
 
+        @argument('connection_id')
         def get_tasks(self, connection_id):
             """
             Get the tasks for a connection.
+            \f
             :param str connection_id: the connection id
             :rtype: list[Task]
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/connections/%s/tasks' % connection_id).json()
 
+        @argument('connection_id')
+        @argument('task', type=JSON)
         def create_task(self, connection_id, task):
             """
             Create a task for a connection.
+            \f
             :param str connection_id: the connection id
             :param Task task: the task
             :rtype: Task
@@ -1124,14 +1320,17 @@ class Client(object):
         def list(self):
             """
             Get all available facilities.
+            \f
             :rtype: list[Facility]
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/facilities').json()
 
+        @argument('facility_id')
         def get(self, facility_id):
             """
             Get a facility with the provided facility id.
+            \f
             :param str facility_id: the facility id
             :rtype: Facility
             :raises: .exception.HttpClientException
@@ -1146,27 +1345,34 @@ class Client(object):
             """
             self.__session = session
 
+        @argument('gateway_id')
         def get(self, gateway_id):
             """
             Get a gateway by its id
+            \f
             :param str gateway_id: the gateway id
             :rtype: Gateway
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/gateways/%s' % gateway_id).json()
 
+        @argument('gateway_id')
         def get_bgp_routes(self, gateway_id):
             """
             Get the bgp routes for a gateway.
+            \f
             :param str gateway_id: the gateway id
             :rtype: list[BGPRoute]
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/gateways/%s/bgpRoutes' % gateway_id).json()
 
+        @argument('gateway_id')
+        @argument('date_filter', type=JSON)
         def get_connectivity_over_time(self, gateway_id, date_filter):
             """
             Get the connectivity details for a gateway by id over time.
+            \f
             :param str gateway_id: the gateway id
             :param DateFilter date_filter: a date filter consisting of 'gt', 'lt', 'gte', 'lte' properties
             :rtype: list[ConnectivityByGateway]
@@ -1174,27 +1380,34 @@ class Client(object):
             """
             return self.__session.post('/gateways/%s/metrics/connectivity' % gateway_id, json=date_filter).json()
 
+        @argument('gateway_id')
         def get_latest_connectivity(self, gateway_id):
             """
             Get the current connectivity details for a gateway by id.
+            \f
             :param str gateway_id: the gateway id
             :rtype: ConnectivityByGateway
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/gateways/%s/metrics/connectivity/current' % gateway_id).json()
 
+        @argument('gateway_id')
         def get_tasks(self, gateway_id):
             """
             Get the tasks for a gateway.
+            \f
             :param str gateway_id: the gateway id
             :rtype: list[Task]
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/gateways/%s/tasks' % gateway_id).json()
 
+        @argument('gateway_id')
+        @argument('task', type=JSON)
         def create_task(self, gateway_id, task):
             """
             Create a task for a gateway.
+            \f
             :param str gateway_id: the gateway id
             :param Task task: the task
             :rtype: Task
@@ -1213,14 +1426,17 @@ class Client(object):
         def list(self):
             """
             Get all available locations.
+            \f
             :rtype: list[Location]
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/locations').json()
 
+        @argument('location_id')
         def get(self, location_id):
             """
             Get a location with the provided location id.
+            \f
             :param str location_id: the location id
             :rtype: Location
             :raises: .exception.HttpClientException
@@ -1235,35 +1451,43 @@ class Client(object):
             """
             self.__session = session
 
+        @argument('network_id')
         def get(self, network_id):
             """
             Get a network with the provided network id.
+            \f
             :param str network_id: the network id
             :rtype: Network
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/networks/%s' % network_id).json()
 
+        @argument('network', type=JSON)
         def update(self, network):
             """
             Update a network.
+            \f
             :param Network network: the network object
             :rtype: Network
             :raises: .exception.HttpClientException
             """
             return self.__session.put('/networks/%s' % network['id'], json=network).json()
 
+        @argument('network_id')
         def delete(self, network_id):
             """
             Delete a network.
+            \f
             :param str network_id: the network id
             :raises: .exception.HttpClientException
             """
             self.__session.delete('/networks/%s' % network_id)
 
+        @argument('network_id')
         def connections(self, network_id):
             """
             Get the account network connections client using the provided account.
+            \f
             :param str network_id: the network id
             :rtype: Client.NetworkConnectionsClient
             """
@@ -1282,14 +1506,19 @@ class Client(object):
         def list(self):
             """
             Get all connections for the provided network.
+            \f
             :rtype: list[Connection]
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/networks/%s/connections' % self.__network_id).json()
 
+        @argument('connection')
+        @option('-w', '--wait_until_active', is_flag=True,
+                help='Wait until the connection is active.')
         def create(self, connection, wait_until_active=False):
             """
             Create a connection for the provided network.
+            \f
             :param Connection connection: the connect object
             :param bool wait_until_active: wait until the connection is active using a backoff retry
             :rtype: Connection
@@ -1316,11 +1545,14 @@ class Client(object):
             """
             self.__session = session
 
+        @option('-t', '--types', multiple=True,
+                help='A filter for the list of enumeration types')
         def list(self, *types):
             """
             List all option objects provided by the API.  These are constant enumerations that are
             used for various parts of the API.  A optional set of **types** may be passed in
             to filter the response.
+            \f
             :param list[str] types: a filter for the list of enumeration types
             :rtype: dict[str, list[Option]]
             :raises: .exception.HttpClientException
@@ -1335,36 +1567,44 @@ class Client(object):
             """
             self.__session = session
 
+        @argument('port_id')
         def get(self, port_id):
             """
             Get the port with the provided port id.
+            \f
             :param str port_id: the port id
             :rtype: Port
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/ports/%s' % port_id).json()
 
+        @argument('port_id')
         def get_accounts_using_port(self, port_id):
             """
             Get the accounts using the port with the provided port id.
+            \f
             :param str port_id: the port id
             :rtype: list[Link]
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/ports/%s/accounts' % port_id).json()
 
+        @argument('port', type=JSON)
         def update(self, port):
             """
             Update a port.
+            \f
             :param Port port: the port object
             :rtype: Port
             :raises: .exception.HttpClientException
             """
             return self.__session.put('/ports/%s' % port['id'], json=port).json()
 
+        @argument('port_id')
         def delete(self, port_id):
             """
             Delete a port.
+            \f
             :param str port_id: the port id
             :raises: .exception.HttpClientException
             """
@@ -1378,9 +1618,11 @@ class Client(object):
             """
             self.__session = session
 
+        @argument('supported_connection_id')
         def get(self, supported_connection_id):
             """
             Get the supported connection with the provided supported connection id.
+            \f
             :param str supported_connection_id: the supported connection id
             :rtype: SupportedConnection
             :raises: .exception.HttpClientException
@@ -1395,18 +1637,24 @@ class Client(object):
             """
             self.__session = session
 
+        @option('-s', '--state',
+                type=Choice(['CREATED', 'RUNNING', 'COMPLETED', 'FAILED', 'DELETED']),
+                help='The task state.')
         def list(self, state=None):
             """
             List all tasks.
+            \f
             :param str state: find all tasks for a particular state
             :rtype: list[Task]
             :raises: .exception.HttpClientException
             """
             return self.__session.get('/tasks', params={'state': state}).json()
 
+        @argument('task_id')
         def get(self, task_id):
             """
             Get a task by it's id.
+            \f
             :param str task_id: the task id
             :rtype: Task
             :raises: .exception.HttpClientException

--- a/pureport/cli/cli.md
+++ b/pureport/cli/cli.md
@@ -1,0 +1,133 @@
+We use [click](https://click.palletsprojects.com/en/7.x/commands/) to drive the CLI and
+this is a description of our CLIs implementation.
+
+Click has many annotations and is largely annotation driven.  
+
+The `@option` & `@argument` annotations store a set of `click.Parameters` on function references
+under the hidden attribute `__click_params__`.  This is done via the `click.decorators._param_memo` function.
+This keeps the function working without any change in functionality.  Therefore, throughout 
+our API client (`pureport.api.client.Client`), we can attach `@option` & `@argument` annotations without any 
+consequential change in functionality.
+
+An `@option` or `@argument` parameter directly maps to the function signature, and the two should map 1-to-1, in order.
+For example:
+
+```python
+from click import argument, option
+
+@option('--a')
+@argument('b')
+def foo(a, b):
+    pass
+```
+
+Click also exposes two other important annotations, `@command` & `@group`.  These annotations
+take the wrapped function and create a `click.Command` or `click.Group` class instance.  These classes look for the
+`__click_params__` hidden attribute and construct a proper CLI command with options and arguments.
+
+The `@group` command constructs a no-command holder for listing out sub-commands.  It can however accept its
+own `@option` & `@argument` annotations.  An example of this would be:
+
+```python
+from click import group, option
+
+@group()
+@option('--account_id')
+def account(account_id):
+    pass
+``` 
+
+A click `@command` on the other hand, is typically a function that does something.
+
+```python
+from click import command, echo, option
+
+@command()
+@option('--account_id')
+def echo_account_id(account_id):
+    echo(account_id)
+``` 
+
+Sub-commands (and sub-groups) can be attached to `@group` functions by prefixing the annotation 
+with the parent function reference.
+
+```python
+from click import group, echo, option
+
+@group()
+def cli():
+    pass
+
+@cli.command()  # cli.command attaches this command to the parent 'cli' group above
+@option('--account_id')
+def echo_account_id(account_id):
+    echo(account_id)
+```
+
+Unfortunately, using `@command` & `@group` annotations rewrite a function reference to be a class instance of 
+`click.Command` or `click.Group` and if we were to do this within our Client classes, it would break the client
+as the functions would no longer be callable via a Python REPL.  Instead, we can create commands/groups by
+creating a new function that wraps the Client function references.
+
+Take for instance the function `Client.AccountsClient.networks(self, account_id)`. The function is actually not 
+callable without a `self` argument that represents an instance of `Client.AccountsClient`.
+
+When we create the initial CLI, we construct an instance of the `Client` class and pass it on as the `context.obj` for
+sub-groups/sub-commands.  A sub-group would then use this `context.obj` as the `self` argument for invocation.  A breakdown
+of that would look like:
+
+```python
+from click import group, pass_context, pass_obj
+from functools import update_wrapper
+from pureport.api.client import Client
+
+@group()
+@pass_context
+def cli(ctx, base_url, api_key, api_secret, access_token):
+    client = Client(base_url=base_url)
+    client.login(api_key, api_secret, access_token)
+    ctx.obj = client.accounts
+
+@pass_obj
+@pass_context
+def networks(ctx, obj, *args, **kwargs):
+    ctx.obj = Client.AccountsClient.networks(obj, *args, **kwargs) # obj here is `client.accounts` passed as `self`
+    # ^ setting new context obj for subcommands
+
+networks = update_wrapper(networks, Client.AccountsClient.networks)
+networks_grp = group()(networks)
+
+cli.add_command(networks_grp)
+```
+
+We can further make this functionality reusable for both groups and commands, by consistently creating groups
+that construct new sub-Client contexts and commands that invoke functions on those sub-clients.
+
+```python
+from click import command, group, pass_context, pass_obj
+from functools import update_wrapper
+from pureport.api.client import Client
+
+def create_client_group(f):
+    @pass_obj
+    @pass_context
+    def new_func(ctx, obj_client_as_self, *args, **kwargs):
+        ctx.obj = f(obj_client_as_self, *args, **kwargs)
+
+    new_func = update_wrapper(new_func, f)
+    return group()(new_func)
+
+def create_client_command(f):
+    @pass_obj
+    def new_func(obj_client_as_self, *args, **kwargs):
+        return f(obj_client_as_self, *args, **kwargs)
+
+    new_func = update_wrapper(new_func, f)
+    return command()(new_func)
+
+account_networks_grp = create_client_group(Client.AccountsClient.networks)
+account_networks_grp.add_command(create_client_command(Client.AccountNetworksClient.list))
+```
+
+In the actual implementation, we recursively loop our client classes and add the commands dynamically, 
+as well as `click.echo` responses when commands execute to dump JSON to the CLI.

--- a/pureport/cli/cli.py
+++ b/pureport/cli/cli.py
@@ -1,0 +1,154 @@
+from click import group, option, pass_context, version_option
+
+from ..api.client import API_URL, Client
+from .util import construct_commands, find_client_commands
+
+
+@group(context_settings={'auto_envvar_prefix': 'PUREPORT'})
+@option('-u', '--base_url', default=API_URL, help='The base url for this client.')
+@option('-k', '--api_key', help='The API Key.')
+@option('-s', '--api_secret', help='The API Key secret.')
+@option('-t', '--access_token', help='The API Key access token.')
+@version_option()
+@pass_context
+def cli(ctx, base_url, api_key, api_secret, access_token):
+    """
+    \f
+    :param click.Context ctx:
+    :param str base_url:
+    :param str api_key:
+    :param str api_secret:
+    :param str access_token:
+    """
+    client = Client(base_url=base_url)
+    client.login(api_key, api_secret, access_token)
+    ctx.obj = client
+
+
+commands = [
+    {
+        'context': Client.accounts,
+        'commands': [
+            Client.AccountsClient.list,
+            Client.AccountsClient.get,
+            Client.AccountsClient.create,
+            Client.AccountsClient.update,
+            Client.AccountsClient.delete,
+            {
+                'context': Client.AccountsClient.api_keys,
+                'commands': find_client_commands(Client.AccountAPIKeysClient)
+            },
+            {
+                'context': Client.AccountsClient.audit_log,
+                'commands': find_client_commands(Client.AccountAuditLogClient)
+            },
+            {
+                'context': Client.AccountsClient.billing,
+                'commands': find_client_commands(Client.AccountBillingClient)
+            },
+            {
+                'context': Client.AccountsClient.connections,
+                'commands': find_client_commands(Client.AccountConnectionsClient)
+            },
+            {
+                'context': Client.AccountsClient.consent,
+                'commands': find_client_commands(Client.AccountConsentClient)
+            },
+            {
+                'context': Client.AccountsClient.invites,
+                'commands': find_client_commands(Client.AccountInvitesClient)
+            },
+            {
+                'context': Client.AccountsClient.invoices,
+                'commands': find_client_commands(Client.AccountInvoicesClient)
+            },
+            {
+                'context': Client.AccountsClient.members,
+                'commands': find_client_commands(Client.AccountMembersClient)
+            },
+            {
+                'context': Client.AccountsClient.metrics,
+                'commands': find_client_commands(Client.AccountMetricsClient)
+            },
+            {
+                'context': Client.AccountsClient.networks,
+                'commands': find_client_commands(Client.AccountNetworksClient)
+            },
+            {
+                'context': Client.AccountsClient.permissions,
+                'commands': find_client_commands(Client.AccountPermissionsClient)
+            },
+            {
+                'context': Client.AccountsClient.ports,
+                'commands': find_client_commands(Client.AccountPortsClient)
+            },
+            {
+                'context': Client.AccountsClient.roles,
+                'commands': find_client_commands(Client.AccountRolesClient)
+            },
+            {
+                'context': Client.AccountsClient.supported_connections,
+                'commands': find_client_commands(Client.AccountSupportedConnectionsClient)
+            },
+            {
+                'context': Client.AccountsClient.supported_ports,
+                'commands': find_client_commands(Client.AccountSupportedPortsClient)
+            }
+        ]
+    },
+    {
+        'context': Client.cloud_regions,
+        'commands': find_client_commands(Client.CloudRegionsClient)
+    },
+    {
+        'context': Client.cloud_services,
+        'commands': find_client_commands(Client.CloudServicesClient)
+    },
+    {
+        'context': Client.connections,
+        'commands': find_client_commands(Client.ConnectionsClient)
+    },
+    {
+        'context': Client.facilities,
+        'commands': find_client_commands(Client.FacilitiesClient)
+    },
+    {
+        'context': Client.gateways,
+        'commands': find_client_commands(Client.GatewaysClient)
+    },
+    {
+        'context': Client.locations,
+        'commands': find_client_commands(Client.LocationsClient)
+    },
+    {
+        'context': Client.networks,
+        'commands': [
+            Client.NetworksClient.get,
+            Client.NetworksClient.update,
+            Client.NetworksClient.delete,
+            {
+                'context': Client.NetworksClient.connections,
+                'commands': find_client_commands(Client.NetworkConnectionsClient)
+            }
+        ]
+    },
+    {
+        'context': Client.options,
+        'commands': find_client_commands(Client.OptionsClient)
+    },
+    {
+        'context': Client.ports,
+        'commands': find_client_commands(Client.PortsClient)
+    },
+    {
+        'context': Client.supported_connections,
+        'commands': find_client_commands(Client.SupportedConnectionsClient)
+    },
+    {
+        'context': Client.tasks,
+        'commands': find_client_commands(Client.TasksClient)
+    }
+]
+
+for command in construct_commands(commands):
+    cli.add_command(command)

--- a/pureport/cli/util.py
+++ b/pureport/cli/util.py
@@ -1,0 +1,101 @@
+from click import command, group, echo, pass_context, pass_obj
+from functools import update_wrapper
+from json import dumps
+from inspect import isgeneratorfunction, isfunction, ismethod
+
+
+def __create_client_group(f):
+    """
+    Constructs a Client Group command.
+
+    Given a reference to the Client class function, e.g. the @property Client.accounts or
+    instance function Client.AccountsClient.networks(account_id), this constructs a click.Group.
+
+    It passes the parent context and parent obj (e.g. the parent Client class instance), then
+    sets a new ctx.obj that is the invocation of this command.  We simply pass along any of
+    *args and **kwargs down into the function.
+
+    The `update_wrapper` is responsible for copying all the actual functions @option/@argument
+    properties to the new function.
+
+    Finally calling `group()(new_func)` creates the Group object and correctly parses all
+    the parameters off the function.
+    :param property|function f:
+    :rtype: click.Group
+    """
+    actual_f = f.fget if isinstance(f, property) else f
+
+    @pass_obj
+    @pass_context
+    def new_func(ctx, obj, *args, **kwargs):
+        ctx.obj = actual_f(obj, *args, **kwargs)
+
+    new_func = update_wrapper(new_func, actual_f)
+    return group()(new_func)
+
+
+def __create_client_command(f):
+    """
+    Constructs a Client Command.
+
+    Given a reference to the Client class function, e.g. the Client.AccountClient.list,
+    this constructs a click.Command.
+
+    It passes the parent Group (see __create_client_group) obj (e.g. the Client class instance), then
+    sets invokes the function reference using the parent context `obj` as the `self` argument
+    of the command.
+
+    The `update_wrapper` is responsible for copying all the actual functions @option/@argument
+    properties to the new function.
+
+    Finally calling `command()(new_func)` creates the Command object and correctly parses all
+    the parameters off the function.
+    :param property|function f:
+    :rtype: click.Command
+    """
+    actual_f = f.fget if isinstance(f, property) else f
+
+    @pass_obj
+    def new_func(obj, *args, **kwargs):
+        response = actual_f(obj, *args, **kwargs)
+        # if the function returns a response, we'll just echo it as JSON
+        if response is not None:
+            echo(dumps(response))
+        return response
+
+    new_func = update_wrapper(new_func, actual_f)
+    return command()(new_func)
+
+
+def find_client_commands(obj):
+    """
+    Given an object, this finds a list of potential commands by
+    listing all public attributes and returning the attributes
+    that are functions.
+    :param object obj:
+    :rtype: list[function]
+    """
+    commands = []
+    for name in dir(obj):
+        if not name.startswith('_'):
+            attr = getattr(obj, name)
+            if isgeneratorfunction(attr) or isfunction(attr) or ismethod(attr):
+                commands.append(attr)
+    return commands
+
+
+def construct_commands(commands):
+    """
+    Recursively construct a list of click.Command or click.Group and
+    attach them to parent groups if necessary.
+    :param list[function|ContextGroup] commands:
+    :rtype: list[click.Command]
+    """
+    for cmd in commands:
+        if isinstance(cmd, dict) and 'context' in cmd:
+            grp = __create_client_group(cmd['context'])
+            for child_cmd in construct_commands(cmd['commands']):
+                grp.add_command(child_cmd)
+            yield grp
+        else:
+            yield __create_client_command(cmd)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
+click
+click-params
 enum34
 requests

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,11 @@ setup(
         'pureport.util.*'
     ]),
     install_requires=read_requirements('requirements.txt'),
+    entry_points={
+        'console_scripts': [
+            'pureport=pureport.cli.cli:cli'
+        ]
+    },
     classifiers=[
         'Programming Language :: Python :: 3',
         'Operating System :: OS Independent',


### PR DESCRIPTION
This uses [click](https://click.palletsprojects.com/en/7.x/) to expose a `pureport` CLI after installing the client via pip.  There is a [README](https://github.com/pureport/pureport-python-client/blob/ecaceaf3d38f5cb621a97213db47ab36e0496225/pureport/cli/cli.md) on how this works and describes how I tried to keep some things as simple as possible.

An example command looks like:
```bash
$ pureport -k foo -s bar accounts api_keys --help
Usage: pureport accounts api_keys [OPTIONS] ACCOUNT_ID COMMAND [ARGS]...

  The account api keys client

Options:
  --help  Show this message and exit.

Commands:
  create  Create an API Key for the provided account.
  delete  Delete an API Key from the provided account.
  get     Get an account's API Key with the provided API Key key.
  list    Get a list of all API keys for an account.
  update  Update an API Key for the provided account.
```

Or with environment variables handling the authentication:
```bash
$ export PUREPORT_API_KEY=foo
$ export PUREPORT_API_SECRET=bar
$ pureport accounts list
```