### PR TITLE
Load credentials from a variety of sources

### DIFF
--- a/pureport/api/client.py
+++ b/pureport/api/client.py
@@ -7,12 +7,13 @@ from os.path import exists, expanduser
 from os import getenv
 from yaml import safe_load
 
-from ..exception.api import \
-    ClientHttpException, \
-    ConnectionOperationFailedException, \
-    ConnectionOperationTimeoutException, \
-    MissingAccessTokenException, \
+from ..exception.api import (
+    ClientHttpException,
+    ConnectionOperationFailedException,
+    ConnectionOperationTimeoutException,
+    MissingAccessTokenException,
     NotFoundException
+)
 from ..util.api import PureportSession
 from ..util.decorators import retry
 

--- a/pureport/api/client.py
+++ b/pureport/api/client.py
@@ -2,7 +2,13 @@
 from click import Choice, argument, option
 from click_params import JSON
 from enum import Enum
+from logging import basicConfig, getLogger
+from os.path import exists, expanduser
+from os import getenv
+from yaml import safe_load
+
 from ..exception.api import \
+    ClientHttpException, \
     ConnectionOperationFailedException, \
     ConnectionOperationTimeoutException, \
     MissingAccessTokenException, \
@@ -12,7 +18,15 @@ from ..util.decorators import retry
 
 __docformat__ = 'reStructuredText'
 
+basicConfig()
+logger = getLogger('pureport.api.client')
+
 API_URL = "https://api.pureport.com"
+API_CONFIG_PATH = expanduser('~/.pureport/credentials.yml')
+ENVIRONMENT_API_URL = 'PUREPORT_API_URL'
+ENVIRONMENT_API_KEY = 'PUREPORT_API_KEY'
+ENVIRONMENT_API_SECRET = 'PUREPORT_API_SECRET'
+ENVIRONMENT_API_PROFILE = 'PUREPORT_API_PROFILE'
 
 """
 TODO(mtraynham): These aliases are simply for documentation.  Maybe in the future we'll extend them
@@ -68,15 +82,28 @@ class ConnectionState(Enum):
 
 
 class Client(object):
-    def __init__(self, base_url=API_URL):
+    def __init__(self, base_url=None,
+                 key=None, secret=None,
+                 access_token=None, profile=None):
         """
         Client for the Pureport ReST API
         This client is a thin wrapper around :module:`requests`.
         All API methods return a :class:`requests.Response` object.  It's up to the user
         to handle exceptions thrown by the API in the form of bad error codes.
         :param str base_url: a base url for the client
+        :param str key: the key to use for login
+        :param str secret: the secret to user for login
+        :param str access_token: the access token obtained externally for an API key
+        :param str profile: the pureport profile to use when using credentials from a file
         """
         self.__session = PureportSession(base_url)
+        try:
+            self.login(key, secret, access_token, profile, base_url)  # Attempt login
+        except MissingAccessTokenException:
+            pass
+        except ClientHttpException as e:
+            logger.exception('There was an attempt to authenticate with '
+                             'Pureport, but it failed.', e)
 
     @staticmethod
     def to_link(standard_object, title):
@@ -94,7 +121,25 @@ class Client(object):
             'title': title,
         }
 
-    def login(self, key=None, secret=None, access_token=None):
+    @staticmethod
+    def __get_file_based_credentials(profile=None):
+        if exists(API_CONFIG_PATH):
+            with open(API_CONFIG_PATH) as f:
+                config = safe_load(f)
+                if 'profiles' in config:
+                    profiles = config['profiles']
+                    potential_profiles = [
+                        profile,
+                        getenv(ENVIRONMENT_API_PROFILE),
+                        config['current_profile'] if 'current_profile' in config else None,
+                        'default'
+                    ]
+                    for potential_profile in potential_profiles:
+                        if potential_profile is not None and potential_profile in profiles:
+                            return profiles[potential_profile]
+        return None
+
+    def login(self, key=None, secret=None, access_token=None, profile=None, api_url=None):
         """
         Login to Pureport ReST API with the specified key and secret or
         pass in a previously obtained access_token.
@@ -102,18 +147,35 @@ class Client(object):
         :param str key: the key to use for login
         :param str secret: the secret to user for login
         :param str access_token: the access token obtained externally for an API key
+        :param str profile: the pureport profile to use when using credentials from a file
+        :param str api_url: the api base url
         :returns: the obtained access_token
         :rtype: str
         :raises: .exception.ClientHttpException
         :raises: .exception.MissingAccessTokenException
         """
-        if key is not None and secret is not None:
-            return self.__session.login(key, secret)
-        elif access_token is not None:
+        file_credentials = Client.__get_file_based_credentials(profile)
+        # Update api base_url
+        base_url = API_URL
+        if api_url is not None:
+            base_url = api_url
+        elif getenv(ENVIRONMENT_API_URL) is not None:
+            base_url = getenv(ENVIRONMENT_API_URL)
+        elif file_credentials is not None and 'api_url' in file_credentials:
+            base_url = file_credentials['api_url']
+        self.__session._base_url = base_url
+        # Update auth token
+        if access_token is not None:
             self.__session.set_access_token(access_token)
             return access_token
-        else:
-            raise MissingAccessTokenException()
+        elif key is not None and secret is not None:
+            return self.__session.login(key, secret)
+        elif getenv(ENVIRONMENT_API_KEY) is not None and getenv(ENVIRONMENT_API_SECRET) is not None:
+            return self.__session.login(getenv(ENVIRONMENT_API_KEY), getenv(ENVIRONMENT_API_SECRET))
+        elif file_credentials is not None and 'api_key' in file_credentials and 'api_secret' in file_credentials:
+            return self.__session.login(file_credentials['api_key'],
+                                        file_credentials['api_secret'])
+        raise MissingAccessTokenException()
 
     @property
     def accounts(self):

--- a/pureport/cli/cli.py
+++ b/pureport/cli/cli.py
@@ -8,21 +8,25 @@ from .util import construct_commands, find_client_commands
 @option('-u', '--api_url', default=API_URL, help='The api url for this client.')
 @option('-k', '--api_key', help='The API Key.')
 @option('-s', '--api_secret', help='The API Key secret.')
+@option('-p', '--api_profile', help='The API Profile if using file-based configuration.')
 @option('-t', '--access_token', help='The API Key access token.')
 @version_option()
 @pass_context
-def cli(ctx, api_url, api_key, api_secret, access_token):
+def cli(ctx, api_url, api_key, api_secret, api_profile, access_token):
     """
     \f
     :param click.Context ctx:
     :param str api_url:
     :param str api_key:
     :param str api_secret:
+    :param str api_profile:
     :param str access_token:
     """
-    client = Client(base_url=api_url)
-    client.login(api_key, api_secret, access_token)
-    ctx.obj = client
+    ctx.obj = Client(base_url=api_url,
+                     key=api_key,
+                     secret=api_secret,
+                     profile=api_profile,
+                     access_token=access_token)
 
 
 commands = [


### PR DESCRIPTION
I tried to keep this largely backwards compatible.

Initialization of the client still accepts a single `base_url` parameter, but it now accepts all parameters that would have typically been passed to `login` and does an initial `login` call.  The initial `login` call will catch the `MissingAccessTokenException` if no valid credentials were found and hopefully expect the user to call `login` as they've done before.

The `login` call has now been expanded to also update the `_base_url` for the client, defaulting to `API_URL` as it had done before.

The order of resolution for both the base url and authorization key/secret is:
- Passed in value (`api_url`, `key`, `secret`)
- Checks environment (`PUREPORT_API_URL`, `PUREPORT_API_KEY`, `PUREPORT_API_SECRET`)
- Checks configuration file `~/.pureport/credentials.yml`)
  - Passed in value for `profile`
  - Checks environment (`PUREPORT_API_PROFILE`)
  - Checks credential file `current_profile`
  - Checks `default` profile

Where a credentials profile looks like:

```yaml
---
current_profile: foobar
profiles:
  default:
    api_key: abc
    api_secret: xyz
    api_url: https://foobar.pureport.com
  foobar:
    api_key: abc
    api_secret: xyz
    api_url: https://foobar.pureport.com
```
