### PR TITLE
Support Python 3.5 by removing click-params dependency

### DIFF
--- a/pureport/api/client.py
+++ b/pureport/api/client.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 from click import Choice, argument, option
-from click_params import JSON
 from enum import Enum
 from logging import basicConfig, getLogger
 from os.path import exists, expanduser
 from os import getenv
 from yaml import safe_load
 
+from ..cli.util import JSON
 from ..exception.api import (
     ClientHttpException,
     ConnectionOperationFailedException,

--- a/pureport/cli/util.py
+++ b/pureport/cli/util.py
@@ -1,10 +1,34 @@
-from click import command, group, echo, pass_context, pass_obj, Choice, Option
+from click import command, group, echo, pass_context, pass_obj, Choice, Option, ParamType
 from functools import update_wrapper
-from json import dumps as json_dumps
+from json import dumps as json_dumps, loads as json_loads, JSONDecodeError
 from inspect import isgeneratorfunction, isfunction, ismethod
 from yaml import dump as yaml_dumps
 
 from ..exception.api import ClientHttpException
+
+
+class __JsonParamType(ParamType):
+    """
+    This is simplified and copied from
+    [click-params](https://click-params.readthedocs.io/en/latest/usage/miscellaneous/#json).
+    This was done because click-params doesn't support Python 3.5, but it's not currently EOL.
+    """
+    name = 'json'
+
+    def __init__(self, **kwargs):
+        self._kwargs = kwargs
+
+    def convert(self, value, param, ctx):
+        try:
+            return json_loads(value, **self._kwargs)
+        except JSONDecodeError:
+            self.fail('%s is not a valid json string' % value, param, ctx)
+
+    def __repr__(self):
+        return self.name.upper()
+
+
+JSON = __JsonParamType()
 
 
 def __insert_click_param(f, param):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 click
-click-params
 enum34
 requests
 PyYaml


### PR DESCRIPTION
This removes the click-params dependency as it does not support Python 3.5 which is not currently EOL, https://devguide.python.org/#status-of-python-branches.

We only needed a small subset of this functionality anyway.  I've validated that it correctly errors when invalid JSON is passed to the CLI client.