### PR TITLE
Moves all sub-group arguments to options with a envvar

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,10 @@ pureport accounts list | jq
 
 ### List all networks for the first account
 first_account_id=$(pureport accounts list --name traynham | jq -r '.[0].id')
-pureport accounts networks $first_account_id list
+pureport accounts networks -a $first_account_id list
 
 ### Create a Network for the Account and persist it's id
-new_network_id=$(pureport accounts networks $first_account_id create '{"name": "My First Network"}' | jq -r '.id')
+new_network_id=$(pureport accounts networks -a $first_account_id create '{"name": "My First Network"}' | jq -r '.id')
 
 ### List all pureport locations
 pureport locations list | jq
@@ -97,7 +97,7 @@ pureport locations list | jq
 location_link=$(pureport locations list | jq -r '.[0] | {id: .id, href: .href, title: .name}')
 
 ### Create an AWS Connection
-new_connection_id=$(pureport networks connections $new_network_id create --wait_until_active '{
+new_connection_id=$(pureport networks connections -n $new_network_id create --wait_until_active '{
     "name": "My First AWS Connection",
     "type": "AWS_DIRECT_CONNECT",
     "speed": 50,

--- a/pureport/api/client.py
+++ b/pureport/api/client.py
@@ -381,7 +381,7 @@ class Client(object):
             """
             self.__session.delete('/accounts/%s' % account_id)
 
-        @argument('account_id')
+        @option('-a', '--account_id', envvar='PUREPORT_ACCOUNT_ID', required=True)
         def api_keys(self, account_id):
             """
             The account api keys client
@@ -391,7 +391,7 @@ class Client(object):
             """
             return Client.AccountAPIKeysClient(self.__session, account_id)
 
-        @argument('account_id')
+        @option('-a', '--account_id', envvar='PUREPORT_ACCOUNT_ID', required=True)
         def audit_log(self, account_id):
             """
             The account audit log client
@@ -401,7 +401,7 @@ class Client(object):
             """
             return Client.AccountAuditLogClient(self.__session, account_id)
 
-        @argument('account_id')
+        @option('-a', '--account_id', envvar='PUREPORT_ACCOUNT_ID', required=True)
         def billing(self, account_id):
             """
             The account billing client
@@ -411,7 +411,7 @@ class Client(object):
             """
             return Client.AccountBillingClient(self.__session, account_id)
 
-        @argument('account_id')
+        @option('-a', '--account_id', envvar='PUREPORT_ACCOUNT_ID', required=True)
         def connections(self, account_id):
             """
             The account connections client
@@ -421,7 +421,7 @@ class Client(object):
             """
             return Client.AccountConnectionsClient(self.__session, account_id)
 
-        @argument('account_id')
+        @option('-a', '--account_id', envvar='PUREPORT_ACCOUNT_ID', required=True)
         def consent(self, account_id):
             """
             The account consent client
@@ -431,7 +431,7 @@ class Client(object):
             """
             return Client.AccountConsentClient(self.__session, account_id)
 
-        @argument('account_id')
+        @option('-a', '--account_id', envvar='PUREPORT_ACCOUNT_ID', required=True)
         def invites(self, account_id):
             """
             The account invites client
@@ -441,7 +441,7 @@ class Client(object):
             """
             return Client.AccountInvitesClient(self.__session, account_id)
 
-        @argument('account_id')
+        @option('-a', '--account_id', envvar='PUREPORT_ACCOUNT_ID', required=True)
         def invoices(self, account_id):
             """
             The account invoices client
@@ -451,7 +451,7 @@ class Client(object):
             """
             return Client.AccountInvoicesClient(self.__session, account_id)
 
-        @argument('account_id')
+        @option('-a', '--account_id', envvar='PUREPORT_ACCOUNT_ID', required=True)
         def members(self, account_id):
             """
             The account members client
@@ -461,7 +461,7 @@ class Client(object):
             """
             return Client.AccountMembersClient(self.__session, account_id)
 
-        @argument('account_id')
+        @option('-a', '--account_id', envvar='PUREPORT_ACCOUNT_ID', required=True)
         def metrics(self, account_id):
             """
             The account metrics client
@@ -471,7 +471,7 @@ class Client(object):
             """
             return Client.AccountMetricsClient(self.__session, account_id)
 
-        @argument('account_id')
+        @option('-a', '--account_id', envvar='PUREPORT_ACCOUNT_ID', required=True)
         def networks(self, account_id):
             """
             The account networks client
@@ -481,7 +481,7 @@ class Client(object):
             """
             return Client.AccountNetworksClient(self.__session, account_id)
 
-        @argument('account_id')
+        @option('-a', '--account_id', envvar='PUREPORT_ACCOUNT_ID', required=True)
         def permissions(self, account_id):
             """
             The account permissions client
@@ -491,7 +491,7 @@ class Client(object):
             """
             return Client.AccountPermissionsClient(self.__session, account_id)
 
-        @argument('account_id')
+        @option('-a', '--account_id', envvar='PUREPORT_ACCOUNT_ID', required=True)
         def ports(self, account_id):
             """
             The account ports client
@@ -501,7 +501,7 @@ class Client(object):
             """
             return Client.AccountPortsClient(self.__session, account_id)
 
-        @argument('account_id')
+        @option('-a', '--account_id', envvar='PUREPORT_ACCOUNT_ID', required=True)
         def roles(self, account_id):
             """
             The account roles client
@@ -511,7 +511,7 @@ class Client(object):
             """
             return Client.AccountRolesClient(self.__session, account_id)
 
-        @argument('account_id')
+        @option('-a', '--account_id', envvar='PUREPORT_ACCOUNT_ID', required=True)
         def supported_connections(self, account_id):
             """
             The account supported connections client
@@ -521,7 +521,7 @@ class Client(object):
             """
             return Client.AccountSupportedConnectionsClient(self.__session, account_id)
 
-        @argument('account_id')
+        @option('-a', '--account_id', envvar='PUREPORT_ACCOUNT_ID', required=True)
         def supported_ports(self, account_id):
             """
             The account supported ports client
@@ -1565,7 +1565,7 @@ class Client(object):
             """
             self.__session.delete('/networks/%s' % network_id)
 
-        @argument('network_id')
+        @option('-n', '--network_id', envvar='PUREPORT_NETWORK_ID', required=True)
         def connections(self, network_id):
             """
             Get the account network connections client using the provided account.

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -3,6 +3,7 @@ from click.testing import CliRunner
 from requests_mock import Adapter
 from re import compile, sub
 from unittest import TestCase
+from os import environ
 
 from pureport.api.client import Client
 from pureport.cli.cli import commands
@@ -95,195 +96,277 @@ class TestAccountsClient(TestCase):
 class TestAccountApiKeysClient(TestCase):
     def test_list(self):
         client.accounts.api_keys('123').list()
-        test_command('accounts', 'api-keys', '123', 'list')
+        test_command('accounts', 'api-keys', '-a', '123', 'list')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'api-keys', 'list')
 
     def test_get(self):
         client.accounts.api_keys('123').get('123')
-        test_command('accounts', 'api-keys', '123', 'get', '123')
+        test_command('accounts', 'api-keys', '-a', '123', 'get', '123')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'api-keys', 'get', '123')
 
     def test_create(self):
         client.accounts.api_keys('123').create({'key': '123'})
-        test_command('accounts', 'api-keys', '123', 'create', '{"key": "123"}')
+        test_command('accounts', 'api-keys', '-a', '123', 'create', '{"key": "123"}')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'api-keys', 'create', '{"key": "123"}')
 
     def test_update(self):
         client.accounts.api_keys('123').update({'key': '123'})
-        test_command('accounts', 'api-keys', '123', 'update', '{"key": "123"}')
+        test_command('accounts', 'api-keys', '-a', '123', 'update', '{"key": "123"}')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'api-keys', 'update', '{"key": "123"}')
 
     def test_delete(self):
         client.accounts.api_keys('123').delete('123')
-        test_command('accounts', 'api-keys', '123', 'delete', '123')
+        test_command('accounts', 'api-keys', '-a', '123', 'delete', '123')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'api-keys', 'delete', '123')
 
 
 class TestAccountAuditLogClient(TestCase):
     def test_query(self):
         client.accounts.audit_log('123').query()
-        test_command('accounts', 'audit-log', '123', 'query')
+        test_command('accounts', 'audit-log', '-a', '123', 'query')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'audit-log', 'query')
 
 
 class TestAccountBillingClient(TestCase):
     def test_get(self):
         client.accounts.billing('123').get()
-        test_command('accounts', 'billing', '123', 'get')
+        test_command('accounts', 'billing', '-a', '123', 'get')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'billing', 'get')
 
     def test_get_configured(self):
         client.accounts.billing('123').get_configured()
-        test_command('accounts', 'billing', '123', 'get-configured')
+        test_command('accounts', 'billing', '-a', '123', 'get-configured')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'billing', 'get-configured')
 
     def test_create(self):
         client.accounts.billing('123').create({})
-        test_command('accounts', 'billing', '123', 'create', '{}')
+        test_command('accounts', 'billing', '-a', '123', 'create', '{}')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'billing', 'create', '{}')
 
     def test_update(self):
         client.accounts.billing('123').update({})
-        test_command('accounts', 'billing', '123', 'update', '{}')
+        test_command('accounts', 'billing', '-a', '123', 'update', '{}')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'billing', 'update', '{}')
 
     def test_delete(self):
         client.accounts.billing('123').delete()
-        test_command('accounts', 'billing', '123', 'delete')
+        test_command('accounts', 'billing', '-a', '123', 'delete')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'billing', 'delete')
 
 
 class TestAccountConnectionsClient(TestCase):
     def test_list(self):
         client.accounts.connections('123').list()
-        test_command('accounts', 'connections', '123', 'list')
+        test_command('accounts', 'connections', '-a', '123', 'list')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'connections', 'list')
 
 
 class TestAccountConsentClient(TestCase):
     def test_get(self):
         client.accounts.consent('123').get()
-        test_command('accounts', 'consent', '123', 'get')
+        test_command('accounts', 'consent', '-a', '123', 'get')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'consent', 'get')
 
     def test_accept(self):
         client.accounts.consent('123').accept()
-        test_command('accounts', 'consent', '123', 'accept')
+        test_command('accounts', 'consent', '-a', '123', 'accept')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'consent', 'accept')
 
 
 class TestAccountInvitesClient(TestCase):
     def test_list(self):
         client.accounts.invites('123').list()
-        test_command('accounts', 'invites', '123', 'list')
+        test_command('accounts', 'invites', '-a', '123', 'list')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'invites', 'list')
 
     def test_get(self):
         client.accounts.invites('123').get('123')
-        test_command('accounts', 'invites', '123', 'get', '123')
+        test_command('accounts', 'invites', '-a', '123', 'get', '123')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'invites', 'get', '123')
 
     def test_create(self):
         client.accounts.invites('123').create({'id': '123'})
-        test_command('accounts', 'invites', '123', 'create', '{"id": "123"}')
+        test_command('accounts', 'invites', '-a', '123', 'create', '{"id": "123"}')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'invites', 'create', '{"id": "123"}')
 
     def test_update(self):
         client.accounts.invites('123').update({'id': '123'})
-        test_command('accounts', 'invites', '123', 'update', '{"id": "123"}')
+        test_command('accounts', 'invites', '-a', '123', 'update', '{"id": "123"}')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'invites', 'update', '{"id": "123"}')
 
     def test_delete(self):
         client.accounts.invites('123').delete('123')
-        test_command('accounts', 'invites', '123', 'delete', '123')
+        test_command('accounts', 'invites', '-a', '123', 'delete', '123')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'invites', 'delete', '123')
 
 
 class TestAccountInvoicesClient(TestCase):
     def test_list(self):
         client.accounts.invoices('123').list({})
-        test_command('accounts', 'invoices', '123', 'list', "{}")
+        test_command('accounts', 'invoices', '-a', '123', 'list', "{}")
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'invoices', 'list', "{}")
 
     def test_list_upcoming(self):
         client.accounts.invoices('123').list_upcoming()
-        test_command('accounts', 'invoices', '123', 'list-upcoming')
+        test_command('accounts', 'invoices', '-a', '123', 'list-upcoming')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'invoices', 'list-upcoming')
 
 
 class TestAccountMembersClient(TestCase):
     def test_list(self):
         client.accounts.members('123').list()
-        test_command('accounts', 'members', '123', 'list')
+        test_command('accounts', 'members', '-a', '123', 'list')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'members', 'list')
 
     def test_get(self):
         client.accounts.members('123').get('123')
-        test_command('accounts', 'members', '123', 'get', '123')
+        test_command('accounts', 'members', '-a', '123', 'get', '123')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'members', 'get', '123')
 
     def test_create(self):
         client.accounts.members('123').create({'user': {'id': '123'}})
-        test_command('accounts', 'members', '123', 'create', '{"id": "123"}')
+        test_command('accounts', 'members', '-a', '123', 'create', '{"id": "123"}')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'members', 'create', '{"id": "123"}')
 
     def test_update(self):
         client.accounts.members('123').update({'user': {'id': '123'}})
-        test_command('accounts', 'members', '123', 'get', '{"id": "123"}')
+        test_command('accounts', 'members', '-a', '123', 'get', '{"id": "123"}')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'members', 'get', '{"id": "123"}')
 
     def test_delete(self):
         client.accounts.members('123').delete('123')
-        test_command('accounts', 'members', '123', 'delete', '123')
+        test_command('accounts', 'members', '-a', '123', 'delete', '123')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'members', 'delete', '123')
 
 
 class TestAccountMetricsClient(TestCase):
     def test_usage_by_connection(self):
         client.accounts.metrics('123').usage_by_connection({})
-        test_command('accounts', 'metrics', '123', 'usage-by-connection', '{}')
+        test_command('accounts', 'metrics', '-a', '123', 'usage-by-connection', '{}')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'metrics', 'usage-by-connection', '{}')
 
     def test_usage_by_connection_and_time(self):
         client.accounts.metrics('123').usage_by_connection_and_time({})
-        test_command('accounts', 'metrics', '123', 'usage-by-connection-and-time', '{}')
+        test_command('accounts', 'metrics', '-a', '123', 'usage-by-connection-and-time', '{}')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'metrics', 'usage-by-connection-and-time', '{}')
 
     def test_usage_by_network_and_time(self):
         client.accounts.metrics('123').usage_by_network_and_time({})
-        test_command('accounts', 'metrics', '123', 'usage-by-network-and-time', '{}')
+        test_command('accounts', 'metrics', '-a', '123', 'usage-by-network-and-time', '{}')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'metrics', 'usage-by-network-and-time', '{}')
 
 
 class TestAccountNetworksClient(TestCase):
     def test_list(self):
         client.accounts.networks('123').list()
-        test_command('accounts', 'networks', '123', 'list')
+        test_command('accounts', 'networks', '-a', '123', 'list')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'networks', 'list')
 
     def test_create(self):
         client.accounts.networks('123').create({})
-        test_command('accounts', 'networks', '123', 'create', '{}')
+        test_command('accounts', 'networks', '-a', '123', 'create', '{}')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'networks', 'create', '{}')
 
 
 class TestAccountPermissionsClient(TestCase):
     def test_get(self):
         client.accounts.permissions('123').get()
-        test_command('accounts', 'permissions', '123', 'get')
+        test_command('accounts', 'permissions', '-a', '123', 'get')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'permissions', 'get')
 
 
 class TestAccountPortsClient(TestCase):
     def test_list(self):
         client.accounts.ports('123').list()
-        test_command('accounts', 'ports', '123', 'list')
+        test_command('accounts', 'ports', '-a', '123', 'list')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'ports', 'list')
 
     def test_create(self):
         client.accounts.ports('123').create({})
-        test_command('accounts', 'ports', '123', 'create', '{}')
+        test_command('accounts', 'ports', '-a', '123', 'create', '{}')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'ports', 'create', '{}')
 
 
 class TestAccountRolesClient(TestCase):
     def test_list(self):
         client.accounts.roles('123').list()
-        test_command('accounts', 'roles', '123', 'list')
+        test_command('accounts', 'roles', '-a', '123', 'list')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'roles', 'list')
 
     def test_get(self):
         client.accounts.roles('123').get('123')
-        test_command('accounts', 'roles', '123', 'get', '123')
+        test_command('accounts', 'roles', '-a', '123', 'get', '123')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'roles', 'get', '123')
 
     def test_create(self):
         client.accounts.roles('123').create({'id': '123'})
-        test_command('accounts', 'roles', '123', 'create', '{"id": "123"}')
+        test_command('accounts', 'roles', '-a', '123', 'create', '{"id": "123"}')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'roles', 'create', '{"id": "123"}')
 
     def test_update(self):
         client.accounts.roles('123').update({'id': '123'})
-        test_command('accounts', 'roles', '123', 'update', '{"id": "123"}')
+        test_command('accounts', 'roles', '-a', '123', 'update', '{"id": "123"}')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'roles', 'update', '{"id": "123"}')
 
     def test_delete(self):
         client.accounts.roles('123').delete('123')
-        test_command('accounts', 'roles', '123', 'get', '123')
+        test_command('accounts', 'roles', '-a', '123', 'get', '123')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'roles', 'get', '123')
 
 
 class TestAccountSupportedConnectionsClient(TestCase):
     def test_list(self):
         client.accounts.supported_connections('123').list()
-        test_command('accounts', 'supported-connections', '123', 'list')
+        test_command('accounts', 'supported-connections', '-a', '123', 'list')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'supported-connections', 'list')
 
 
 class TestAccountSupportedPortsClient(TestCase):
     def test_list(self):
         client.accounts.supported_ports('123').list('123')
-        test_command('accounts', 'supported-ports', '123', 'list', '123')
+        test_command('accounts', 'supported-ports', '-a', '123', 'list', '123')
+        environ['PUREPORT_ACCOUNT_ID'] = '123'
+        test_command('accounts', 'supported-ports', 'list', '123')
 
 
 class TestCloudRegionsClient(TestCase):
@@ -391,11 +474,15 @@ class TestNetworksClient(TestCase):
 class TestNetworkConnectionsClient(TestCase):
     def test_get(self):
         client.networks.connections('123').list()
-        test_command('networks', 'connections', '123', 'list')
+        test_command('networks', 'connections', '-n', '123', 'list')
+        environ['PUREPORT_NETWORK_ID'] = '123'
+        test_command('networks', 'connections', 'list')
 
     def test_create(self):
         client.networks.connections('123').create({})
-        test_command('networks', 'connections', '123', 'create', '{}')
+        test_command('networks', 'connections', '-n', '123', 'create', '{}')
+        environ['PUREPORT_NETWORK_ID'] = '123'
+        test_command('networks', 'connections', 'create', '{}')
 
 
 class TestOptionsClient(TestCase):


### PR DESCRIPTION
Click doesn't have great support for arguments with `envvar`
defaults because it's hard to infer what is actually an
argument parameter vs subcommand.  The documentation
suggests the better approach is to use options instead.

I wrote a test suite to make sure you couldn't use arguments with `envvar`
as sub-group options.  The last test case which is similar to our setup
always fails because Click can't infer the difference between a subcommand and
a missing argument of a subgroup.

E.g.
```
export PUREPORT_ACCOUNT_ID = 'foobar'
pureport accounts networks list
```

The above thinks `list` is the passed account id, and then it blows up because it can't find a subcommand to execute.

Here's the test suite.

```python
from click import group, argument
from click.testing import CliRunner
from unittest import TestCase
from os import environ


class TestArgumentEnv(TestCase):
    def test_subcommand(self):
        @group()
        def cli():
            pass

        @cli.command()
        @argument('arg', envvar='TEST')
        def subcommand(arg):
            pass

        result = CliRunner().invoke(cli, args=['subcommand', 'arg'])
        assert result.exit_code == 0

    def test_subcommand_env(self):
        @group()
        def cli():
            pass

        @cli.command()
        @argument('arg', envvar='TEST')
        def subcommand(arg):
            pass

        environ['TEST'] = 'arg'
        result = CliRunner().invoke(cli, args=['subcommand'])
        assert result.exit_code == 0

    def test_subgroup_command(self):
        @group()
        def cli():
            pass

        @cli.group()
        @argument('arg', envvar='TEST')
        def subgroup(arg):
            pass

        @subgroup.command()
        def subcommand():
            pass

        result = CliRunner().invoke(cli, args=['subgroup', 'arg', 'subcommand'])
        assert result.exit_code == 0

    def test_subgroup_env_command(self):
        @group()
        def cli():
            pass

        @cli.group()
        @argument('arg', envvar='TEST')
        def subgroup(arg):
            pass

        @subgroup.command()
        def subcommand():
            pass

        environ['TEST'] = 'foo'
        result = CliRunner().invoke(cli, args=['subgroup', 'subcommand'])
        assert result.exit_code == 0
```