### PR TITLE
Removes unnecessary enum34 dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 click
-enum34
 requests
 PyYaml


### PR DESCRIPTION
This removes enum34 as we only support Py >= 3.5.

Also corrects the unittest invocation.