### PR TITLE
[PE-2292] Missing requirements files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include *.md
 recursive-include docs *.md
+include *.txt


### PR DESCRIPTION
Fixes #30.
Include the requirements files in source distribution.