### PR TITLE
implement python package logging

### DIFF
--- a/pureport_client/client.py
+++ b/pureport_client/client.py
@@ -12,11 +12,7 @@ from os.path import (
 )
 
 from enum import Enum
-
-from logging import (
-    basicConfig,
-    getLogger
-)
+from logging import getLogger
 
 from yaml import safe_load
 
@@ -42,8 +38,7 @@ from pureport_client.helpers import (
     retry
 )
 
-basicConfig()
-logger = getLogger('pureport.api.client')
+log = getLogger(__name__)
 
 API_URL = "https://api.pureport.com"
 API_CONFIG_PATH = expanduser('~/.pureport/credentials.yml')
@@ -158,7 +153,7 @@ class Client(object):
         except MissingAccessTokenException:
             pass
         except ClientHttpException as e:
-            logger.exception('There was an attempt to authenticate with '
+            log.exception('There was an attempt to authenticate with '
                              'Pureport, but it failed.', e)
 
     @staticmethod

--- a/pureport_client/session.py
+++ b/pureport_client/session.py
@@ -67,7 +67,6 @@ class PureportSession(RelativeSession, RaiseForStatusSession):
         self.set_access_token(result['access_token'])
         self._refresh_token = result['refresh_token']
         self._token_expire_time = time.time() + result['expires_in']
-
         return self._access_token
 
     def set_access_token(self, access_token):


### PR DESCRIPTION
This commit implements python logging for the entire package.  The
logger is configured to display nothin unless explicity configured.  To
configure logging use the convenience function as such:

```
import pureport_client
pureport_client.set_logging(10)
```

The above example code will turn on debug logging for the entire
pureport-client package

Signed-off-by: Peter Sprygada <peter.sprygada@pureport.com>