### PR TITLE
refactors PureportClientConnectionError class

### DIFF
--- a/pureport_client/exceptions.py
+++ b/pureport_client/exceptions.py
@@ -4,6 +4,27 @@
 # Copyright (c) 2020, Pureport, Inc.
 # All Rights Reserved
 
+"""
+The Pureport exceptions module provies all error classes used in this
+project.  It provides a class hierarchy where all errors derive from the
+```PureportClientError``` exception.
+
+::
+
+    PureportClientError
+      +-- PureportConnectionError
+      |     +-- ConnectionOperationTimeoutError
+      |     +-- ConnectionOperationFailedError
+      +-- MissingAccessTokenError
+      +-- ClientHttpError
+
+
+The exceptions module is pureposefully kept small and additional exception
+classes should ony be added if there is a specific reason to do so.
+Good reasons include adding mandatory arguments such as the case with
+```ClientHttpError```.
+"""
+
 from __future__ import absolute_import
 
 
@@ -34,7 +55,7 @@ class PureportClientError(Exception):
         return self._exc
 
 
-class PureportClientConnectionError(PureportClientError):
+class PureportConnectionError(PureportClientError):
 
     def __init__(self, *args, **kwargs):
         """ Base error class for all Pureport connection errors
@@ -43,7 +64,7 @@ class PureportClientConnectionError(PureportClientError):
         :type connection: Connection
         """
         self._connection = kwargs.pop('connection', None)
-        super(PureportClientConnectionError, self).__init__(*args, **kwargs)
+        super(PureportConnectionError, self).__init__(*args, **kwargs)
 
     @property
     def connection(self):
@@ -54,13 +75,13 @@ class MissingAccessTokenError(PureportClientError):
     pass
 
 
-class ConnectionOperationTimeoutError(PureportClientConnectionError):
+class ConnectionOperationTimeoutError(PureportConnectionError):
     """A connection operation that too long to complete
     """
     pass
 
 
-class ConnectionOperationFailedError(PureportClientConnectionError):
+class ConnectionOperationFailedError(PureportConnectionError):
     """A connection opertion that failed to complete
     """
     pass

--- a/test/unit/test_exceptions.py
+++ b/test/unit/test_exceptions.py
@@ -25,7 +25,7 @@ def test_pureport_client_connection_error():
     obj = MagicMock()
     conn = MagicMock()
 
-    exc = exceptions.PureportClientConnectionError(message, obj, connection=conn)
+    exc = exceptions.PureportConnectionError(message, obj, connection=conn)
 
     assert isinstance(exc, exceptions.PureportClientError)
     assert exc.message == message
@@ -44,7 +44,7 @@ def test_connection_operation_timeout_exception():
     message = utils.random_string()
     exc = exceptions.ConnectionOperationTimeoutError(message)
     assert isinstance(exc, exceptions.PureportClientError)
-    assert isinstance(exc, exceptions.PureportClientConnectionError)
+    assert isinstance(exc, exceptions.PureportConnectionError)
     assert exc.message == message
 
 
@@ -52,7 +52,7 @@ def test_connection_operation_failed_exception():
     message = utils.random_string()
     exc = exceptions.ConnectionOperationFailedError(message)
     assert isinstance(exc, exceptions.PureportClientError)
-    assert isinstance(exc, exceptions.PureportClientConnectionError)
+    assert isinstance(exc, exceptions.PureportConnectionError)
     assert exc.message == message
 
 


### PR DESCRIPTION
This commit refactors the `PureportClientConnectionError` class to
`PureportConnectionError`.  All child classes have been updated as
necessary to support the rename.

This change also adds a module description to
`pureport_client.exceptions` to provide details about the implementation
and the exception class hierarchy.

Signed-off-by: Peter Sprygada <peter.sprygada@pureport.com>