### PR TITLE
document and clean up commands base classes

### DIFF
--- a/pureport_client/commands/__init__.py
+++ b/pureport_client/commands/__init__.py
@@ -13,42 +13,114 @@ log = getLogger(__name__)
 
 
 class CommandBase(object):
+    """Base implementation of a CLI command
+    """
 
-    def __init__(self, session=None):
-        self._client = session
+    def __init__(self, client=None):
+        """Create a new instance of `CommandBase`
+
+        :param client: the Pureport API client instance
+        :type client: `pureport_client.client.Client`
+
+        :returns: an instance of CommandBase
+        :rtype: `pureport_client.commands.CommandBase`
+        """
+        self._client = client
 
     client = property(lambda self: self._client)
-    session = property(lambda self: self._client.session)
 
     def __call__(self, method, url, *args, **kwargs):
-        log.debug('{} {}'.format(method.upper(), url))
-        return getattr(self.session, method.lower())(url, *args, **kwargs).json()
+        """Send the request to the API and return the results
 
-    def _request(self, method, url, *args, **kwargs):
-        return self.__call__(method, url, *args, **kwargs)
+        :param method: the HTTP method to call
+        :type method: str
+
+        :param url: the URL to send the call to
+        :type url: str
+
+        :returns: the body of the reponse convered from json
+        :rtype: dict (or list)
+        """
+        log.debug('{} {}'.format(method.upper(), url))
+        return getattr(self.client.request, method)(url, *args, **kwargs).json()
 
 
 class AccountsMixin(object):
+    """Mixin class for prepending accounts url
+    """
 
-    def __init__(self, session, account_id):
-        super(AccountsMixin, self).__init__(session)
+    def __init__(self, client, account_id):
+        """Create a new instance of `AccountsMixin`
+
+        :param client: the Pureport API client instance
+        :type client: `pureport_client.client.Client`
+
+        :param account_id: the Pureport account ID to use as the URL base
+        :type account_id: str
+
+        :returns: an instance of AccountsMixin
+        :rtype: `pureport_client.commands.AccountsMixin`
+        """
+
+        super(AccountsMixin, self).__init__(client)
         self._account_id = account_id
 
     account_id = property(lambda self: self._account_id)
 
     def __call__(self, method, url, *args, **kwargs):
+        """Send the request to the API and return the results
+
+        This overload prepends `/accounts/{ account_id }` to the
+        provided URL before sending it to the remote server.
+
+        :param method: the HTTP method to call
+        :type method: str
+
+        :param url: the URL to send the call to
+        :type url: str
+
+        :returns: the body of the reponse convered from json
+        :rtype: dict (or list)
+        """
         url = urllib.parse.urljoin('/accounts/{}/'.format(self.account_id), url)
         return super(AccountsMixin, self).__call__(method, url, *args, **kwargs)
 
 
 class NetworksMixin(object):
+    """Mixin class for prepending networks url
+    """
 
-    def __init__(self, session, account_id):
-        super(NetworksMixin, self).__init__(session)
-        self._network_id = account_id
+    def __init__(self, client, network_id):
+        """Create a new instance of `NetworksMixin`
+
+        :param client: the Pureport API client instance
+        :type client: `pureport_client.client.Client`
+
+        :param account_id: the Pureport network ID to use as the URL base
+        :type account_id: str
+
+        :returns: an instance of NetworksMixin
+        :rtype: `pureport_client.commands.NetworksMixin`
+        """
+        super(NetworksMixin, self).__init__(client)
+        self._network_id = network_id
 
     network_id = property(lambda self: self._network_id)
 
     def __call__(self, method, url, *args, **kwargs):
+        """Send the request to the API and return the results
+
+        This overload prepends `/networks/{ network_id }` to the
+        provided URL before sending it to the remote server.
+
+        :param method: the HTTP method to call
+        :type method: str
+
+        :param url: the URL to send the call to
+        :type url: str
+
+        :returns: the body of the reponse convered from json
+        :rtype: dict (or list)
+        """
         url = urllib.parse.urljoin('/networks/{}/'.format(self.network_id), url)
         return super(NetworksMixin, self).__call__(method, url, *args, **kwargs)

--- a/pureport_client/commands/__init__.py
+++ b/pureport_client/commands/__init__.py
@@ -42,7 +42,7 @@ class CommandBase(object):
         :rtype: dict (or list)
         """
         log.debug('{} {}'.format(method.upper(), url))
-        return getattr(self.client.request, method)(url, *args, **kwargs).json()
+        return getattr(self.client.session, method)(url, *args, **kwargs).json()
 
 
 class AccountsMixin(object):


### PR DESCRIPTION
This commit fixes up some mis named private instance variables and addes
doc strings to the classes and methods in `pureport_client.commands`.
This commit doesn't introduce any code path changes.

Signed-off-by: Peter Sprygada <peter.sprygada@pureport.com>