### PR TITLE
add plugin loading via entry points

### DIFF
--- a/pureport_client/util.py
+++ b/pureport_client/util.py
@@ -113,10 +113,10 @@ def create_print_wrapper(f):
             raise e
     new_func = update_wrapper(new_func, f)
     insert_click_param(new_func,
-                         Option(['--format'],
-                                type=Choice(['json_pp', 'json', 'yaml']),
-                                default='json_pp',
-                                help='Specify how responses should be formatted and echoed to the terminal.'))
+                        Option(['--format'],
+                               type=Choice(['json_pp', 'json', 'yaml']),
+                               default='json_pp',
+                               help='Specify how responses should be formatted and echoed to the terminal.'))
     return new_func
 
 


### PR DESCRIPTION
This commit adds a new feature that allows for command plugins to be
devleoped.  Plugins are loaded using Python entry points.  To load cli
plugin, the entry point needs to configured as
`pureport_client.plugins`.  All plugins are loaded first and then the
core commands are loaded preventing overwrite of core commands.

Signed-off-by: Peter Sprygada <peter.sprygada@pureport.com>