### PR TITLE
roll up of minor updates

### DIFF
--- a/pureport_client/exceptions.py
+++ b/pureport_client/exceptions.py
@@ -72,24 +72,35 @@ class PureportConnectionError(PureportClientError):
 
 
 class MissingAccessTokenError(PureportClientError):
-    pass
+    """Missing access token for authentication
+    """
+
+    def __init__(self, message=None):
+        message = message or "missing access token"
+        super(MissingAccessTokenError, self).__init__(message)
 
 
 class ConnectionOperationTimeoutError(PureportConnectionError):
     """A connection operation that too long to complete
     """
-    pass
+
+    def __init__(self, message=None, *args, **kwargs):
+        message = message or "connection operation timed out"
+        super(ConnectionOperationTimeoutError, self).__init__(message, *args, **kwargs)
 
 
 class ConnectionOperationFailedError(PureportConnectionError):
     """A connection opertion that failed to complete
     """
-    pass
+
+    def __init__(self, message=None, *args, **kwargs):
+        message = message or "connection operation failed"
+        super(ConnectionOperationFailedError, self).__init__(message, *args, **kwargs)
 
 
 class ClientHttpError(PureportClientError):
 
-    def __init__(self, status_code, reason, *args, **kwargs):
+    def __init__(self, status_code, reason):
         """ An exception representing a bad http call from the client
 
         :param status_code: The numeric HTTP status code return from
@@ -101,7 +112,8 @@ class ClientHttpError(PureportClientError):
         """
         self._status_code = status_code
         self._reason = reason
-        super(ClientHttpError, self).__init__(*args, **kwargs)
+        message = "{} {}".format(status_code, reason)
+        super(ClientHttpError, self).__init__(message)
 
     @property
     def status_code(self):

--- a/pureport_client/helpers.py
+++ b/pureport_client/helpers.py
@@ -53,7 +53,7 @@ def format_date(value):
                     .strftime(SERVER_DATE_FORMAT)
             except ValueError:
                 pass
-        raise ValueError()
+        raise ValueError(value)
 
 
 def retry(exception, tries=10, delay=1, backoff=2, max_delay=30):

--- a/pureport_client/util.py
+++ b/pureport_client/util.py
@@ -29,8 +29,6 @@ from click import (
 
 from yaml import dump as yaml_dumps
 
-from pureport_client.exceptions import ClientHttpError
-
 
 class JsonParamType(ParamType):
     """Backports the click json param type to python 3.5
@@ -96,27 +94,24 @@ def create_print_wrapper(f):
     :rtype: function
     """
     def new_func(*args, **kwargs):
-        try:
-            response_format = kwargs.pop('format')
-            response = f(*args, **kwargs)
-            # if the function returns a response, we'll just echo it as JSON
-            if response is not None:
-                if response_format == 'json_pp':
-                    echo(json_dumps(response, indent=2, sort_keys=True))
-                elif response_format == 'json':
-                    echo(json_dumps(response))
-                elif response_format == 'yaml':
-                    echo(yaml_dumps(response))
-            return response
-        except ClientHttpError as e:
-            echo(e.response.text)
-            raise e
+        response_format = kwargs.pop('format')
+        response = f(*args, **kwargs)
+        # if the function returns a response, we'll just echo it as JSON
+        if response is not None:
+            if response_format == 'json_pp':
+                echo(json_dumps(response, indent=2, sort_keys=True))
+            elif response_format == 'json':
+                echo(json_dumps(response))
+            elif response_format == 'yaml':
+                echo(yaml_dumps(response))
+        return response
+
     new_func = update_wrapper(new_func, f)
     insert_click_param(new_func,
-                        Option(['--format'],
-                               type=Choice(['json_pp', 'json', 'yaml']),
-                               default='json_pp',
-                               help='Specify how responses should be formatted and echoed to the terminal.'))
+                       Option(['--format'],
+                              type=Choice(['json_pp', 'json', 'yaml']),
+                              default='json_pp',
+                              help='Specify how responses should be formatted and echoed to the terminal.'))
     return new_func
 
 

--- a/test/unit/commands/__init__.py
+++ b/test/unit/commands/__init__.py
@@ -86,12 +86,17 @@ cli = __create_mock_cli(client)
 
 def run_command_test(parent, child, *args, **kwargs):
     command = shlex.split(parent)
+
     cli_options = kwargs.pop('cli_options', None)
+    cli_options_post = kwargs.pop('cli_options_post', None)
 
     if cli_options:
         command.extend(shlex.split(cli_options))
 
     command.append(child)
+
+    if cli_options_post:
+        command.extend(shlex.split(cli_options_post))
 
     for a in args:
         if isinstance(a, dict):

--- a/test/unit/commands/test_connections.py
+++ b/test/unit/commands/test_connections.py
@@ -18,6 +18,14 @@ def test_update():
     run_command_test('connections', 'update', {'id': utils.random_string()})
 
 
+# FIXME currently the run_command_test doesn't provide a way to control the
+# response from the mocked object.  need to update the run_command_test
+# function to include this option
+# def test_update_wait():
+#     run_command_test('connections', 'update', {'id': utils.random_string()},
+#                      cli_options_post="-w")
+
+
 def test_delete():
     run_command_test('connections', 'delete', utils.random_string())
 

--- a/test/unit/test_exceptions.py
+++ b/test/unit/test_exceptions.py
@@ -57,11 +57,10 @@ def test_connection_operation_failed_exception():
 
 
 def test_client_http_exception():
-    message = utils.random_string()
     status_code = utils.random_int()
     reason = utils.random_string()
-    exc = exceptions.ClientHttpError(status_code, reason, message)
+    exc = exceptions.ClientHttpError(status_code, reason)
     assert isinstance(exc, exceptions.PureportClientError)
-    assert exc.message == message
+    assert exc.message == "{} {}".format(status_code, reason)
     assert exc.status_code == status_code
     assert exc.reason == reason

--- a/test/unit/test_helpers.py
+++ b/test/unit/test_helpers.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*_
+#
+# Copyright (c) 2020, Pureport, Inc.
+# All Rights Reserved
+
+import datetime
+
+import pytest
+
+from pureport_client import helpers
+
+from ..utils import utils
+
+
+def test_format_date_string():
+    for item in ('2020/01/01', '2020-01-01', '2020.01.01', '2020,01,01',
+                 '2020-01-01T00', '2020-01-01T00:00', '2020-01-01T00:00:00'):
+        helpers.format_date(item)
+
+
+def test_format_date_string_invalid():
+    with pytest.raises(ValueError):
+        helpers.format_date(utils.random_string())
+
+
+def test_format_date_date():
+    helpers.format_date(datetime.date.today())


### PR DESCRIPTION
This commit is a roll up of updates that address a number of fixes.

* ClientHttpError is no longer caught in the print function and is now
  the responsibility of the command to handle it
* Fixes error when using wait option for updating and deleting
  connections
* Adds optional message positional argument to exception classes with a
  default message if a more specific one isn't provided
* Removes the message positional argument from ClientHttpError and now
  automatically generates a message based on the status code and reason
* Adds test cases for the `pureport_client.helpers` module

Signed-off-by: Peter Sprygada <peter.sprygada@pureport.com>